### PR TITLE
fix(engine): spell-checker does not replace entities anymore

### DIFF
--- a/packages/nlu/src/engine/engine/predict-pipeline.ts
+++ b/packages/nlu/src/engine/engine/predict-pipeline.ts
@@ -160,7 +160,7 @@ async function extractSlots(input: IntentStep, predictors: Predictors): Promise<
 
 async function spellCheck(input: SlotStep, predictors: Predictors, tools: Tools): Promise<SpellStep> {
   const spellChecker = makeSpellChecker(predictors.vocab, input.languageCode, tools)
-  const spellChecked = await spellChecker(input.utterance.toString({ entities: 'keep-value', slots: 'keep-value' }))
+  const spellChecked = await spellChecker(input.utterance.toString({ entities: 'keep-default', slots: 'keep-default' }))
   return {
     ...input,
     spellChecked

--- a/packages/nlu/src/engine/engine/utterance/utterance.ts
+++ b/packages/nlu/src/engine/engine/utterance/utterance.ts
@@ -11,7 +11,7 @@ import { ExtractedEntity, ExtractedSlot, TFIDF, Tools } from '../typings'
 export interface UtteranceToStringOptions {
   lowerCase?: boolean
   onlyWords?: boolean
-  slots?: 'keep-value' | 'keep-name' | 'ignore'
+  slots?: 'keep-default' | 'keep-value' | 'keep-name' | 'ignore'
   entities?: 'keep-default' | 'keep-value' | 'keep-name' | 'ignore'
 }
 
@@ -188,6 +188,8 @@ export default class Utterance {
       if (tok.slots.length && options.slots === 'keep-name') {
         toAdd = tok.slots[0].name
       } else if (tok.slots.length && options.slots === 'keep-value') {
+        toAdd = tok.value
+      } else if (tok.slots.length && options.slots === 'keep-default') {
         toAdd = tok.value
       } else if (tok.entities.length && options.entities === 'keep-name') {
         toAdd = tok.entities[0].type


### PR DESCRIPTION
Prevents this to happen:

![image](https://user-images.githubusercontent.com/25970722/118335009-ae006b80-b4dc-11eb-81ec-dad12c18348b.png)
