### PR TITLE
chore: run list entity extraction on child threads with progress report

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,19 @@
       "autoAttachChildProcesses": true,
       "args": ["--config=./config.json"],
       "outFiles": ["${workspaceRoot}/packages/**/*.js", "${workspaceRoot}/node_modules/**/*.js"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
     }
   ]
 }

--- a/packages/nlu/src/engine/engine/entities/custom-extractor/index.ts
+++ b/packages/nlu/src/engine/engine/entities/custom-extractor/index.ts
@@ -3,6 +3,7 @@ import { extractPattern } from '../../tools/patterns-utils'
 import { EntityExtractionResult, ListEntityModel, PatternEntity, WarmedListEntityModel } from '../../typings'
 import Utterance from '../../utterance/utterance'
 import { extractForListModel } from './list-extraction'
+import { serializeUtteranceToken } from './serializable-token'
 
 interface SplittedModels {
   withCacheHit: WarmedListEntityModel[]
@@ -11,8 +12,9 @@ interface SplittedModels {
 
 export class CustomEntityExtractor {
   public extractListEntities(utterance: Utterance, list_entities: ListEntityModel[]): EntityExtractionResult[] {
+    const serializedTokens = utterance.tokens.map(serializeUtteranceToken)
     return _(list_entities)
-      .map((model) => extractForListModel(utterance, model))
+      .map((model) => extractForListModel(serializedTokens, model))
       .flatten()
       .value()
   }
@@ -80,7 +82,8 @@ export class CustomEntityExtractor {
 
     const extractedMatches: EntityExtractionResult[] = _(withCacheMiss)
       .map((model) => {
-        const extractions = extractForListModel(utterance, model)
+        const serializedTokens = utterance.tokens.map(serializeUtteranceToken)
+        const extractions = extractForListModel(serializedTokens, model)
         model.cache.set(cacheKey, extractions)
         return extractions
       })

--- a/packages/nlu/src/engine/engine/entities/custom-extractor/index.ts
+++ b/packages/nlu/src/engine/engine/entities/custom-extractor/index.ts
@@ -1,0 +1,106 @@
+import _ from 'lodash'
+import { extractPattern } from '../../tools/patterns-utils'
+import { EntityExtractionResult, ListEntityModel, PatternEntity, WarmedListEntityModel } from '../../typings'
+import Utterance from '../../utterance/utterance'
+import { extractForListModel } from './list-extraction'
+
+interface SplittedModels {
+  withCacheHit: WarmedListEntityModel[]
+  withCacheMiss: WarmedListEntityModel[]
+}
+
+export class CustomEntityExtractor {
+  public extractListEntities(utterance: Utterance, list_entities: ListEntityModel[]): EntityExtractionResult[] {
+    return _(list_entities)
+      .map((model) => extractForListModel(utterance, model))
+      .flatten()
+      .value()
+  }
+
+  public extractPatternEntities = (
+    utterance: Utterance,
+    pattern_entities: PatternEntity[]
+  ): EntityExtractionResult[] => {
+    const input = utterance.toString()
+    // taken from pattern_extractor
+    return _.flatMap(pattern_entities, (ent) => {
+      const regex = new RegExp(ent.pattern!, ent.matchCase ? '' : 'i')
+
+      return extractPattern(input, regex, []).map((res) => ({
+        confidence: 1,
+        start: Math.max(0, res.sourceIndex),
+        end: Math.min(input.length, res.sourceIndex + res.value.length),
+        value: res.value,
+        metadata: {
+          extractor: 'pattern',
+          source: res.value,
+          entityId: `custom.pattern.${ent.name}`
+        },
+        sensitive: ent.sensitive,
+        type: ent.name
+      }))
+    })
+  }
+
+  public async extractMultipleListEntities(
+    utterances: Utterance[],
+    list_entities: WarmedListEntityModel[],
+    progress: (p: number) => void
+  ): Promise<EntityExtractionResult[][]> {
+    let idx = 0
+    return utterances.map((u) => {
+      const res = this._extractMultipleListEntities(u, list_entities)
+      progress(idx++ / utterances.length)
+      return res
+    })
+  }
+
+  public async extractMultiplePatternEntities(
+    utterances: Utterance[],
+    pattern_entities: PatternEntity[],
+    progress: (p: number) => void
+  ): Promise<EntityExtractionResult[][]> {
+    let idx = 0
+    return utterances.map((u) => {
+      const res = this.extractPatternEntities(u, pattern_entities)
+      progress(idx++ / utterances.length)
+      return res
+    })
+  }
+
+  private _extractMultipleListEntities(utterance: Utterance, list_entities: WarmedListEntityModel[]) {
+    // no need to "keep-value" of entities as this function's purpose is precisly to extract entities before tagging them in the utterance.
+    const cacheKey = utterance.toString({ lowerCase: true })
+    const { withCacheHit, withCacheMiss } = this._splitModelsByCacheHitOrMiss(list_entities, cacheKey)
+
+    const cachedMatches: EntityExtractionResult[] = _.flatMap(
+      withCacheHit,
+      (listModel) => listModel.cache.get(cacheKey)!
+    )
+
+    const extractedMatches: EntityExtractionResult[] = _(withCacheMiss)
+      .map((model) => {
+        const extractions = extractForListModel(utterance, model)
+        model.cache.set(cacheKey, extractions)
+        return extractions
+      })
+      .flatten()
+      .value()
+
+    return [...cachedMatches, ...extractedMatches]
+  }
+
+  private _splitModelsByCacheHitOrMiss(listModels: WarmedListEntityModel[], cacheKey: string): SplittedModels {
+    return listModels.reduce(
+      ({ withCacheHit, withCacheMiss }, nextModel) => {
+        if (nextModel.cache.has(cacheKey)) {
+          withCacheHit.push(nextModel)
+        } else {
+          withCacheMiss.push(nextModel)
+        }
+        return { withCacheHit, withCacheMiss }
+      },
+      { withCacheHit: [], withCacheMiss: [] } as SplittedModels
+    )
+  }
+}

--- a/packages/nlu/src/engine/engine/entities/custom-extractor/list-extraction.ts
+++ b/packages/nlu/src/engine/engine/entities/custom-extractor/list-extraction.ts
@@ -12,7 +12,7 @@ function takeUntil(
 ): SerializableUtteranceToken[] {
   let total = 0
   const result = _.takeWhile(arr.slice(start), (t) => {
-    const toAdd = t.toString().length
+    const toAdd = tokenToString(t).length
     const current = total
     if (current > 0 && Math.abs(desiredLength - current) < Math.abs(desiredLength - current - toAdd)) {
       // better off as-is

--- a/packages/nlu/src/engine/engine/entities/custom-extractor/multi-thread-extractor.ts
+++ b/packages/nlu/src/engine/engine/entities/custom-extractor/multi-thread-extractor.ts
@@ -1,3 +1,160 @@
+import { makeThreadPool } from '@botpress/worker'
+import Bluebird from 'bluebird'
+import _ from 'lodash'
+import os from 'os'
+import path from 'path'
+import Logger from '../../../../utils/logger'
+import { EntityExtractionResult, ListEntityModel, WarmedListEntityModel } from '../../typings'
+import Utterance from '../../utterance/utterance'
 import { CustomEntityExtractor } from '.'
+import { SerializableUtteranceToken, serializeUtteranceToken } from './serializable-token'
 
-export class MultiThreadCustomEntityExtractor extends CustomEntityExtractor {}
+const THREAD_ENTRY_POINT = 'thread-entry-point.js'
+
+const maxMLThreads = Math.max(os.cpus().length - 1, 1) // ncpus - webworker
+const userMlThread = process.env.BP_NUM_ML_THREADS ? Number(process.env.BP_NUM_ML_THREADS) : 4
+const numMLThreads = Math.min(maxMLThreads, userMlThread)
+
+interface TaskUnitInput {
+  utt_idx: number
+  entity_idx: number
+  utterance: Utterance
+  list_entity: WarmedListEntityModel
+}
+
+interface SerializableTaskUnitInput {
+  utt_idx: number
+  entity_idx: number
+  tokens: SerializableUtteranceToken[]
+  list_entity: ListEntityModel
+}
+
+interface TaskUnitOutput {
+  utt_idx: number
+  entity_idx: number
+  entities: EntityExtractionResult[]
+}
+
+export interface TaskInput {
+  units: SerializableTaskUnitInput[]
+}
+
+export interface TaskOutput {
+  units: TaskUnitOutput[]
+}
+
+const logger = Logger.sub('training').sub('entities')
+
+const threadPool = makeThreadPool<TaskInput, TaskOutput>(logger, {
+  entryPoint: path.join(__dirname, THREAD_ENTRY_POINT),
+  env: { ...process.env },
+  maxWorkers: numMLThreads
+})
+
+export class MultiThreadCustomEntityExtractor extends CustomEntityExtractor {
+  public async extractMultipleListEntities(
+    utterances: Utterance[],
+    list_entities: WarmedListEntityModel[],
+    progress: (p: number) => void
+  ) {
+    const allTaskUnits = this._getAllTaskUnits(utterances, list_entities)
+    const [cacheHit, cacheMiss] = this._splitUnitsByCacheHitOrMiss(allTaskUnits)
+
+    const cacheHitResults = cacheHit.map((unit) => {
+      const { entity_idx, utt_idx, list_entity, utterance } = unit
+      const cacheKey = this._getCacheKey(utterance)
+      return {
+        entity_idx,
+        utt_idx,
+        entities: list_entity.cache.get(cacheKey)!
+      }
+    })
+
+    const cacheMissResults = await this._launchOnThreads(cacheMiss, progress)
+    this._updateCache(utterances, list_entities, cacheMissResults)
+    return this._mapOutputs([...cacheHitResults, ...cacheMissResults])
+  }
+
+  private async _launchOnThreads(units: TaskUnitInput[], progress: (p: number) => void) {
+    const unitsPerWorker = Math.ceil(units.length / numMLThreads)
+    const chunks = _(units).map(this.serializeUnit).chunk(unitsPerWorker).value()
+
+    const progressPerWorker: _.Dictionary<number> = {}
+    let idx = 0
+    const threadOutputs = await Bluebird.map(chunks, (chunk) => {
+      idx++
+      const taskId = `${idx++}`
+      return threadPool.run(taskId, { units: chunk }, (p: number) => {
+        progressPerWorker[taskId] = p
+        const totalProgress = _(progressPerWorker).values().sum()
+        progress(totalProgress / chunks.length)
+      })
+    })
+
+    return _.flatMap(threadOutputs, (u) => u.units)
+  }
+
+  private serializeUnit(unit: TaskUnitInput): SerializableTaskUnitInput {
+    const { entity_idx, utt_idx, utterance, list_entity: warmedModel } = unit
+    const { cache, ...coldModel } = warmedModel
+    const { tokens } = utterance
+    return { entity_idx, utt_idx, tokens: tokens.map(serializeUtteranceToken), list_entity: coldModel }
+  }
+
+  private _splitUnitsByCacheHitOrMiss(units: TaskUnitInput[]): [TaskUnitInput[], TaskUnitInput[]] {
+    const cacheHit: TaskUnitInput[] = []
+    const cacheMiss: TaskUnitInput[] = []
+    for (const unit of units) {
+      const { utterance, list_entity } = unit
+      const cacheKey = this._getCacheKey(utterance)
+      if (list_entity.cache.has(cacheKey)) {
+        cacheHit.push(unit)
+      } else {
+        cacheMiss.push(unit)
+      }
+    }
+    return [cacheHit, cacheMiss]
+  }
+
+  private _getAllTaskUnits(utterances: Utterance[], list_entities: WarmedListEntityModel[]): TaskUnitInput[] {
+    const allTaskUnits: TaskUnitInput[] = []
+    for (let i = 0; i < utterances.length; i++) {
+      for (let j = 0; j < list_entities.length; j++) {
+        allTaskUnits.push({
+          utt_idx: i,
+          entity_idx: j,
+          utterance: utterances[i],
+          list_entity: list_entities[j]
+        })
+      }
+    }
+    return allTaskUnits
+  }
+
+  private _updateCache(
+    utterances: Utterance[],
+    list_entities: WarmedListEntityModel[],
+    outputs: TaskUnitOutput[]
+  ): void {
+    for (const out of outputs) {
+      const { entity_idx, utt_idx, entities } = out
+      const utterance = utterances[utt_idx]
+      const cacheKey = this._getCacheKey(utterance)
+      list_entities[entity_idx].cache.set(cacheKey, entities)
+    }
+  }
+
+  private _mapOutputs(outputs: TaskUnitOutput[]): EntityExtractionResult[][] {
+    return _(outputs)
+      .groupBy((o) => o.utt_idx)
+      .mapValues((ox) => _.flatMap(ox, (o) => o.entities))
+      .toPairs()
+      .orderBy(([idx, e]) => Number(idx))
+      .map(([idx, e]) => e)
+      .value()
+  }
+
+  private _getCacheKey(utterance: Utterance) {
+    return utterance.toString({ lowerCase: true })
+  }
+}

--- a/packages/nlu/src/engine/engine/entities/custom-extractor/multi-thread-extractor.ts
+++ b/packages/nlu/src/engine/engine/entities/custom-extractor/multi-thread-extractor.ts
@@ -1,0 +1,3 @@
+import { CustomEntityExtractor } from '.'
+
+export class MultiThreadCustomEntityExtractor extends CustomEntityExtractor {}

--- a/packages/nlu/src/engine/engine/entities/custom-extractor/serializable-token.ts
+++ b/packages/nlu/src/engine/engine/entities/custom-extractor/serializable-token.ts
@@ -1,0 +1,29 @@
+import { convertToRealSpaces } from '../../tools/token-utils'
+import { DefaultTokenToStringOptions, TokenToStringOptions, UtteranceToken } from '../../utterance/utterance'
+
+export type SerializableUtteranceToken = Omit<UtteranceToken, 'toString'>
+
+export const serializeUtteranceToken = (token: UtteranceToken): SerializableUtteranceToken => {
+  const { toString, ...otherFields } = token
+  return { ...otherFields }
+}
+
+/**
+ *
+ * @description Copied from UtteranceToken.toString()
+ * @returns a string
+ */
+export const tokenToString = (token: SerializableUtteranceToken, opts: Partial<TokenToStringOptions> = {}) => {
+  const options = { ...DefaultTokenToStringOptions, ...opts }
+  let result = token.value
+  if (options.lowerCase) {
+    result = result.toLowerCase()
+  }
+  if (options.realSpaces) {
+    result = convertToRealSpaces(result)
+  }
+  if (options.trim) {
+    result = result.trim()
+  }
+  return result
+}

--- a/packages/nlu/src/engine/engine/entities/custom-extractor/thread-entry-point.ts
+++ b/packages/nlu/src/engine/engine/entities/custom-extractor/thread-entry-point.ts
@@ -1,0 +1,23 @@
+import { makeThreadEntryPoint, TaskDefinition } from '@botpress/worker'
+import { extractForListModel } from './list-extraction'
+import { TaskInput, TaskOutput } from './multi-thread-extractor'
+
+const main = async () => {
+  const threadEntryPoint = makeThreadEntryPoint<TaskInput, TaskOutput>()
+
+  threadEntryPoint.listenForTask(async (taskDef: TaskDefinition<TaskInput>) => {
+    const { input, progress } = taskDef
+    let i = 0
+    const N = input.units.length
+    const units = input.units.map((u) => {
+      const { utt_idx, entity_idx, list_entity, tokens } = u
+      const entities = extractForListModel(tokens, list_entity)
+      progress(i++ / N)
+      return { utt_idx, entity_idx, entities }
+    })
+    return { units }
+  })
+
+  await threadEntryPoint.initialize()
+}
+void main()

--- a/packages/nlu/src/engine/engine/entities/duckling-extractor/duckling-extractor.test.ts
+++ b/packages/nlu/src/engine/engine/entities/duckling-extractor/duckling-extractor.test.ts
@@ -30,10 +30,12 @@ describe('Duckling Extract Multiple', () => {
     unlinkSync(testCachePath)
   })
 
+  const dummyProgress = (p: number) => {}
+
   test('When disabled returns empty array for each input', async () => {
     duck.disable()
     const examples = ['this is one', 'this is two']
-    const res = await duck.extractMultiple(examples, 'en')
+    const res = await duck.extractMultiple(examples, 'en', dummyProgress)
     expect(mockedFetch).not.toHaveBeenCalled()
     res.forEach((r) => {
       expect(r).toEqual([])
@@ -43,21 +45,21 @@ describe('Duckling Extract Multiple', () => {
   test('calls extract with join char', async () => {
     const examples = ['this is one', 'this is two']
     mockedFetch.mockResolvedValue([])
-    await duck.extractMultiple(examples, 'en')
+    await duck.extractMultiple(examples, 'en', dummyProgress)
     expect(mockedFetch.mock.calls[0][0]).toContain(JOIN_CHAR)
   })
 
   test('returns as many results as n examples with single batch', async () => {
     mockedFetch.mockResolvedValue([])
     const examples = ['this is one', 'this is two', 'this is three']
-    const res = await duck.extractMultiple(examples, 'en')
+    const res = await duck.extractMultiple(examples, 'en', dummyProgress)
     expect(res.length).toEqual(examples.length)
   })
 
   test('returns as many results as n examples with multiple batches', async () => {
     mockedFetch.mockResolvedValue([])
     const examples = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '11', '12', '13', '14']
-    const res = await duck.extractMultiple(examples, 'en')
+    const res = await duck.extractMultiple(examples, 'en', dummyProgress)
     expect(res.length).toEqual(examples.length)
   })
 
@@ -74,7 +76,7 @@ describe('Duckling Extract Multiple', () => {
     ]
 
     mockedFetch.mockResolvedValueOnce(extractedEntities)
-    const res = await duck.extractMultiple(examples, 'en')
+    const res = await duck.extractMultiple(examples, 'en', dummyProgress)
     expect(res[0].length).toEqual(3)
     expect(res[0][0].start).toEqual(0)
     expect(res[0][0].end).toEqual(3)
@@ -92,8 +94,8 @@ describe('Duckling Extract Multiple', () => {
     const ex = 'one two three'
     mockedFetch.mockResolvedValue([])
 
-    await duck.extractMultiple([ex], 'en', false)
-    await duck.extractMultiple([ex], 'en', false)
+    await duck.extractMultiple([ex], 'en', dummyProgress, false)
+    await duck.extractMultiple([ex], 'en', dummyProgress, false)
 
     expect(mockedFetch).toHaveBeenCalledTimes(2)
     // make sure ex isn't removed from 2nd call
@@ -107,8 +109,13 @@ describe('Duckling Extract Multiple', () => {
     mockedFetch.mockResolvedValueOnce(cachedExRes)
     mockedFetch.mockResolvedValue([])
 
-    const firstCall = await duck.extractMultiple([cachedEx], 'en', true)
-    const secondCall = await duck.extractMultiple([cachedEx, 'nothing', 'nothing 2', cachedEx], 'en', true)
+    const firstCall = await duck.extractMultiple([cachedEx], 'en', dummyProgress, true)
+    const secondCall = await duck.extractMultiple(
+      [cachedEx, 'nothing', 'nothing 2', cachedEx],
+      'en',
+      dummyProgress,
+      true
+    )
 
     expect(firstCall[0]).toEqual(cachedExRes)
     expect(firstCall[0]).toEqual(secondCall[0])

--- a/packages/nlu/src/engine/engine/entities/list-extractor.test.ts
+++ b/packages/nlu/src/engine/engine/entities/list-extractor.test.ts
@@ -1,9 +1,13 @@
 import { makeTestUtterance } from '../test-utils/fake-utterance'
 
 import { EntityExtractionResult, ListEntityModel } from '../typings'
+import Utterance from '../utterance/utterance'
 import { parseUtterance } from '../utterance/utterance-parser'
 
-import { extractListEntities } from './custom-entity-extractor'
+import { CustomEntityExtractor } from './custom-extractor/index'
+
+const extractor = new CustomEntityExtractor()
+const extractListEntities = (utt: Utterance, models: ListEntityModel[]) => extractor.extractListEntities(utt, models)
 
 const FuzzyTolerance = {
   Loose: 0.65,

--- a/packages/nlu/src/engine/engine/entities/microsoft-extractor/index.ts
+++ b/packages/nlu/src/engine/engine/entities/microsoft-extractor/index.ts
@@ -41,6 +41,7 @@ export class MicrosoftEntityExtractor implements SystemEntityExtractor {
   public async extractMultiple(
     inputs: string[],
     lang: string,
+    progress: (p: number) => void,
     useCache?: boolean
   ): Promise<EntityExtractionResult[][]> {
     const options: MicrosoftParams = !isSupportedLanguage(lang)
@@ -53,6 +54,7 @@ export class MicrosoftEntityExtractor implements SystemEntityExtractor {
     const [cached, toFetch] = this._cache.splitCacheHitFromCacheMiss(inputs, !!useCache)
 
     const batchedRes = await this._extractBatch(toFetch, options)
+    progress(1)
 
     return _.chain(batchedRes)
       .flatten()
@@ -63,7 +65,8 @@ export class MicrosoftEntityExtractor implements SystemEntityExtractor {
   }
 
   public async extract(input: string, lang: string, useCache?: boolean): Promise<EntityExtractionResult[]> {
-    return (await this.extractMultiple([input], lang, useCache))[0]
+    const dummyProgress = () => {}
+    return (await this.extractMultiple([input], lang, dummyProgress, useCache))[0]
   }
 
   private formatEntity(entity: MicrosoftEntity): EntityExtractionResult {

--- a/packages/nlu/src/engine/engine/entities/microsoft-extractor/microsoft-extractor.test.ts
+++ b/packages/nlu/src/engine/engine/entities/microsoft-extractor/microsoft-extractor.test.ts
@@ -7,6 +7,8 @@ import { createSpyObject, MockObject } from '../../../../utils/mock-extra'
 import { Logger } from '../../../typings'
 import { KeyedItem } from '../../typings'
 
+const dummyProgess = (p: number) => {}
+
 describe('Microsoft Extract Multiple', () => {
   let microsoft: MicrosoftEntityExtractor
   let testCachePath = path.join(' ', 'cache', 'testCache.json')
@@ -25,7 +27,7 @@ describe('Microsoft Extract Multiple', () => {
 
   test('Return nothing for unsupported lang', async () => {
     const examples = ['один два три четыре пять', 'Я говорю по русски сегодня, но и завтра вечером']
-    const res = await microsoft.extractMultiple(examples, 'ru')
+    const res = await microsoft.extractMultiple(examples, 'ru', dummyProgess)
     res.forEach((r) => {
       expect(r).toEqual([])
     })
@@ -134,7 +136,7 @@ describe('Microsoft Extract Multiple', () => {
       'пн электронная почта est hello@helloworld.com',
       'Мой сайт www.thecuteboys.com, пожалуйста, напишите отзыв'
     ]
-    const res = await microsoft.extractMultiple(examples, 'ru')
+    const res = await microsoft.extractMultiple(examples, 'ru', dummyProgess)
 
     for (const [prem, hyp] of _.zip(res, expected)) {
       expect(prem).toHaveLength(1)
@@ -153,7 +155,7 @@ describe('Microsoft Extract Multiple', () => {
       'Is it five degrees outside ?',
       'Oh yes please'
     ]
-    const res = await microsoft.extractMultiple(examples, 'en')
+    const res = await microsoft.extractMultiple(examples, 'en', dummyProgess)
     expect(res.length).toEqual(examples.length)
   })
 
@@ -261,7 +263,7 @@ describe('Microsoft Extract Multiple', () => {
       ]
     ]
 
-    const res = await microsoft.extractMultiple(examples, 'en')
+    const res = await microsoft.extractMultiple(examples, 'en', dummyProgess)
 
     expect(res).toEqual(result)
   })

--- a/packages/nlu/src/engine/engine/predict-pipeline.ts
+++ b/packages/nlu/src/engine/engine/predict-pipeline.ts
@@ -10,7 +10,7 @@ import {
   PredictOutput
 } from '../../typings_v1'
 
-import { extractListEntities, extractPatternEntities } from './entities/custom-entity-extractor'
+import { CustomEntityExtractor } from './entities/custom-extractor'
 import { IntentPrediction, IntentPredictions, NoneableIntentPredictions } from './intents/intent-classifier'
 import { OOSIntentClassifier } from './intents/oos-intent-classfier'
 import { SvmIntentClassifier } from './intents/svm-intent-classifier'
@@ -98,10 +98,11 @@ async function makePredictionUtterance(input: InitialStep, predictors: Predictor
 async function extractEntities(input: PredictStep, predictors: Predictors, tools: Tools): Promise<PredictStep> {
   const { utterance } = input
 
+  const customEntityExtractor = new CustomEntityExtractor()
   _.forEach(
     [
-      ...extractListEntities(utterance, predictors.list_entities),
-      ...extractPatternEntities(utterance, predictors.pattern_entities),
+      ...customEntityExtractor.extractListEntities(utterance, predictors.list_entities),
+      ...customEntityExtractor.extractPatternEntities(utterance, predictors.pattern_entities),
       ...(await tools.systemEntityExtractor.extract(utterance.toString(), utterance.languageCode))
     ],
     (entityRes) => {

--- a/packages/nlu/src/engine/engine/test-utils/fake-tools.ts
+++ b/packages/nlu/src/engine/engine/test-utils/fake-tools.ts
@@ -81,7 +81,7 @@ export const makeFakeTools = (dim: number, languages: string[]): Tools => {
   }
 
   const fakeSystemEntityExtractor: SystemEntityExtractor = {
-    extractMultiple: async (input: string[], lang: string, useCache?: Boolean) => [],
+    extractMultiple: async (input: string[], lang: string, progress: (p: number) => void, useCache?: Boolean) => [],
     extract: async (input: string, lang: string) => []
   }
 

--- a/packages/nlu/src/engine/engine/training-pipeline.ts
+++ b/packages/nlu/src/engine/engine/training-pipeline.ts
@@ -4,7 +4,7 @@ import { MLToolkit } from '../../ml/typings'
 import { Logger } from '../typings'
 
 import { serializeKmeans } from './clustering'
-import { CustomEntityExtractor } from './entities/custom-extractor'
+import { MultiThreadCustomEntityExtractor } from './entities/custom-extractor/multi-thread-extractor'
 import { warmEntityCache } from './entities/entity-cache-manager'
 import { getCtxFeatures } from './intents/context-featurizer'
 import { OOSIntentClassifier } from './intents/oos-intent-classfier'
@@ -268,7 +268,7 @@ async function ExtractEntities(input: TrainStep, tools: Tools, progress: progres
   tools.logger?.debug('Extracting list entities')
 
   step = 1
-  const customEntityExtractor = new CustomEntityExtractor()
+  const customEntityExtractor = new MultiThreadCustomEntityExtractor()
   const allListEntities = await customEntityExtractor.extractMultipleListEntities(
     utterances,
     input.list_entities,

--- a/packages/nlu/src/engine/engine/training-pipeline.ts
+++ b/packages/nlu/src/engine/engine/training-pipeline.ts
@@ -4,7 +4,7 @@ import { MLToolkit } from '../../ml/typings'
 import { Logger } from '../typings'
 
 import { serializeKmeans } from './clustering'
-import { extractListEntitiesWithCache, extractPatternEntities } from './entities/custom-entity-extractor'
+import { CustomEntityExtractor } from './entities/custom-extractor'
 import { warmEntityCache } from './entities/entity-cache-manager'
 import { getCtxFeatures } from './intents/context-featurizer'
 import { OOSIntentClassifier } from './intents/oos-intent-classfier'
@@ -230,7 +230,7 @@ async function TrainContextClassifier(input: TrainStep, tools: Tools, progress: 
       nluSeed
     },
     (p) => {
-      progress(_.round(p, 1))
+      progress(p)
     }
   )
 
@@ -249,21 +249,51 @@ async function ProcessIntents(
   })
 }
 
-async function ExtractEntities(input: TrainStep, tools: Tools): Promise<TrainStep> {
+async function ExtractEntities(input: TrainStep, tools: Tools, progress: progressCB): Promise<TrainStep> {
   const utterances: Utterance[] = _.chain(input.intents).flatMap('utterances').value()
 
+  tools.logger?.debug('Extracting system entities')
+
+  const clampedProgress = (p: number) => progress(Math.min(0.99, p))
+
+  let step = 0
   // we extract sys entities for all utterances, helps on training and exact matcher
   const allSysEntities = await tools.systemEntityExtractor.extractMultiple(
     utterances.map((u) => u.toString()),
     input.languageCode,
+    (p: number) => clampedProgress((step + p) / 3),
     true
   )
 
-  _.zipWith(utterances, allSysEntities, (utt, sysEntities) => ({ utt, sysEntities }))
-    .map(({ utt, sysEntities }) => {
-      const listEntities = extractListEntitiesWithCache(utt, input.list_entities)
-      const patternEntities = extractPatternEntities(utt, input.pattern_entities)
-      return [utt, [...sysEntities, ...listEntities, ...patternEntities]] as [Utterance, EntityExtractionResult[]]
+  tools.logger?.debug('Extracting list entities')
+
+  step = 1
+  const customEntityExtractor = new CustomEntityExtractor()
+  const allListEntities = await customEntityExtractor.extractMultipleListEntities(
+    utterances,
+    input.list_entities,
+    (p: number) => clampedProgress((step + p) / 3)
+  )
+
+  tools.logger?.debug('Extracting pattern entities')
+
+  step = 2
+  const allPatternEntities = await customEntityExtractor.extractMultiplePatternEntities(
+    utterances,
+    input.pattern_entities,
+    (p: number) => clampedProgress((step + p) / 3)
+  )
+
+  progress(1)
+
+  _.zipWith(utterances, allSysEntities, allListEntities, allPatternEntities, (utt, sys, list, pattern) => ({
+    utt,
+    sys,
+    list,
+    pattern
+  }))
+    .map(({ utt, sys, list, pattern }) => {
+      return [utt, [...sys, ...list, ...pattern]] as [Utterance, EntityExtractionResult[]]
     })
     .forEach(([utt, entities]) => {
       entities.forEach((ent) => {
@@ -338,10 +368,7 @@ export const Trainer = async (input: TrainInput, tools: Tools, progress: (x: num
   let totalProgress = 0
   let normalizedProgress = 0
 
-  const emptyProgress = () => {}
-  const reportTrainingProgress = progress ?? emptyProgress
-
-  const debouncedProgress = _.debounce(reportTrainingProgress, 75, { maxWait: 750 })
+  const debouncedProgress = _.debounce(progress, 75, { maxWait: 750 })
   const reportProgress: progressCB = (stepProgress = 1) => {
     totalProgress = Math.max(totalProgress, Math.floor(totalProgress) + _.round(stepProgress, 2))
     const scaledProgress = Math.min(1, _.round(totalProgress / NB_STEPS, 2))
@@ -353,16 +380,14 @@ export const Trainer = async (input: TrainInput, tools: Tools, progress: (x: num
   }
   const logger = makeLogger(input.trainId, tools.logger)
 
-  reportTrainingProgress(0) // 0%
+  progress(0) // 0%
 
   let step = await logger(PreprocessInput)(input, tools)
-  reportProgress() // 20%
-
   step = await logger(TfidfTokens)(step)
   step = await logger(ClusterTokens)(step, tools)
-  step = await logger(ExtractEntities)(step, tools)
-  reportProgress() // 40%
+  reportProgress(1) // 20%
 
+  step = await logger(ExtractEntities)(step, tools, reportProgress)
   const models = await Promise.all([
     logger(TrainContextClassifier)(step, tools, reportProgress),
     logger(TrainIntentClassifiers)(step, tools, reportProgress),

--- a/packages/nlu/src/engine/engine/typings.ts
+++ b/packages/nlu/src/engine/engine/typings.ts
@@ -143,7 +143,12 @@ export interface Tools {
 }
 
 export interface SystemEntityExtractor {
-  extractMultiple(input: string[], lang: string, useCache?: Boolean): Promise<EntityExtractionResult[][]>
+  extractMultiple(
+    input: string[],
+    lang: string,
+    progress: (p: number) => void,
+    useCache?: Boolean
+  ): Promise<EntityExtractionResult[][]>
   extract(input: string, lang: string): Promise<EntityExtractionResult[]>
 }
 


### PR DESCRIPTION
For some bot with few list entities

| - | Cold Training Time (s) |
| ------------- |:-------------:|
| without child threads      | 38.141 |
| with 4 child threads | 12.277 |

There's 4 new threads in the training process:

![image](https://user-images.githubusercontent.com/25970722/119739016-99fb2900-be4f-11eb-93ba-4d6e3b320faa.png)
