### PR TITLE
chore(nlu): standardize logs

### DIFF
--- a/packages/nlu/src/lang-server/index.ts
+++ b/packages/nlu/src/lang-server/index.ts
@@ -32,7 +32,7 @@ export default async function (options: ArgV) {
 
   options.langDir = options.langDir || path.join(process.APP_DATA_PATH, 'embeddings')
 
-  const launcherLogger = Logger.sub('launcher')
+  const launcherLogger = Logger.sub('Launcher')
   // Launcher always display
   launcherLogger.configure({
     level: LoggerLevel.Info,

--- a/packages/nlu/src/stan/index.ts
+++ b/packages/nlu/src/stan/index.ts
@@ -53,7 +53,7 @@ export default async function (cliOptions: CommandLineOptions, version: string) 
     filters: options.logFilter
   })
 
-  const launcherLogger = Logger.sub('launcher')
+  const launcherLogger = Logger.sub('Launcher')
   // Launcher always display
   launcherLogger.configure({
     level: Math.max(options.verbose, LoggerLevel.Info),

--- a/packages/nlu/src/utils/logger/formatters/console.ts
+++ b/packages/nlu/src/utils/logger/formatters/console.ts
@@ -30,7 +30,7 @@ export class ConsoleFormatter implements LogEntryFormatter {
     const time = moment().format(config.timeFormat)
     const serializedMetadata = entry.metadata ? _serializeArgs(entry.metadata) : ''
 
-    const displayName = this._opts.indent ? entry.namespace.substr(0, 15).padEnd(15, ' ') : entry.namespace
+    const displayName = this._opts.indent ? entry.namespace.substr(0, 15).padEnd(15, ' ') : `[NLU] ${entry.namespace}`
     // eslint-disable-next-line prefer-template
     const newLineIndent = chalk.dim(' '.repeat(`${config.timeFormat} ${displayName}`.length)) + ' '
     let indentedMessage =


### PR DESCRIPTION
Since we are going to have multiple processes running on a single server, it would be nice if we could differentiate the various logs in the console. The logger adds `[Studio]` for all logs studio-related, so this would simply add `[NLU]` to logs. I guess we could add a prefix for the core logs eventually

It doesn't adresses the fact that users on the admin will not see logs from either the studio or the nlu, but we'll see that in the future

![image](https://user-images.githubusercontent.com/42552874/119746089-9c647f80-be5d-11eb-91bd-3f4928a41fa9.png)
