### PR TITLE
fix(logger): launcher debug logs are not displayed by default when verbose is 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.1.2](https://github.com/botpress/nlu/compare/v0.1.1...v0.1.2) (2021-06-07)
+
+
+### Bug Fixes
+
+* **logger:** launcher debug logs are not displayed by default when verbose is 4 ([503f0d8](https://github.com/botpress/nlu/commit/503f0d8d040b00bf3fa1538acb2b6e40c4731f75))
+
+
+### Features
+
+* rename env config variable ([e886829](https://github.com/botpress/nlu/commit/e886829bc5b582f63e70a283406f1459b6f2821a))
+
+
+
 ## [0.1.1](https://github.com/botpress/nlu/compare/v0.1.0...v0.1.1) (2021-06-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@
 # [0.1.0](https://github.com/botpress/nlu/compare/v0.0.7...v0.1.0) (2021-06-07)
 
 
+### Bug Fixes
+
+* **build:** test Docker build ([a93d3f3](https://github.com/botpress/nlu/commit/a93d3f3d357e449b782d22af17625c510a1b155f))
+* **build:** test Docker build ([29e3443](https://github.com/botpress/nlu/commit/29e34433de1e16353f96f6378b1305c926504975))
+* **nlu:** remove database connection string from logs ([0dd1d76](https://github.com/botpress/nlu/commit/0dd1d763cc7eb45b520cbc37f4f6be4b65799dbb))
+* **nlu:** remove database connection string from logs ([b2185b3](https://github.com/botpress/nlu/commit/b2185b3442ae80ad657e89d31934607e4d5c2b59))
+
+
 ### Features
 
 * run list entity extraction on child threads with progress report ([#38](https://github.com/botpress/nlu/issues/38)) ([0ddc473](https://github.com/botpress/nlu/commit/0ddc4731365c5c9f98eea64d70491ee8ecadd25d))

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ RUN yarn package
 
 FROM ubuntu:18.04
 
-COPY --from=build /nlu/dist/nlu-v0_1_0-linux-x64 /nlu
+COPY --from=build /nlu/dist/nlu-v0_1_2-linux-x64 /nlu
 
 CMD ["/nlu"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/nlu",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Botpress Standalone NLU Server. Contains all of Botpress NLU related code.",
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",

--- a/packages/nlu/package.json
+++ b/packages/nlu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nlu",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Botpress NLU main package",
   "main": "./dist/index.js",
   "author": "Botpress, Inc.",

--- a/packages/nlu/src/index.ts
+++ b/packages/nlu/src/index.ts
@@ -99,8 +99,7 @@ yargs
         description:
           'Filter logs by namespace, ex: "--log-filter training:svm api". Namespaces are space separated. Does not apply to "Launcher" logger.',
         array: true,
-        type: 'string',
-        default: []
+        type: 'string'
       }
     },
     (argv) => {

--- a/packages/nlu/src/nlu-server/api.ts
+++ b/packages/nlu/src/nlu-server/api.ts
@@ -47,7 +47,7 @@ export interface APIOptions {
   modelDir?: string
   verbose: number
   doc: boolean
-  logFilter: string[]
+  logFilter?: string[]
 }
 
 const requestLogger = Logger.sub('api').sub('request')

--- a/packages/nlu/src/nlu-server/config.ts
+++ b/packages/nlu/src/nlu-server/config.ts
@@ -55,7 +55,7 @@ const _mapCli = (c: CommandLineOptions): StanOptions => {
 }
 
 const readEnvJSONConfig = (): StanOptions | null => {
-  const rawContent = process.env.STAN_JSON_CONFIG
+  const rawContent = process.env.NLU_SERVER_CONFIG
   if (!rawContent) {
     return null
   }

--- a/packages/nlu/src/nlu-server/index.ts
+++ b/packages/nlu/src/nlu-server/index.ts
@@ -2,44 +2,13 @@ import bytes from 'bytes'
 import chalk from 'chalk'
 import _ from 'lodash'
 import path from 'path'
-import * as NLUEngine from '../engine'
 import Logger, { centerText } from '../utils/logger'
-import { LoggerLevel, ILogger } from '../utils/logger/typings'
+import { LoggerLevel } from '../utils/logger/typings'
 import API from './api'
-import { CommandLineOptions, getConfig, StanOptions } from './config'
+import { CommandLineOptions, getConfig } from './config'
 import { copyDir } from './copy-dir'
 import { displayDocumentation } from './documentation'
-
-const makeEngine = async (options: StanOptions, logger: ILogger) => {
-  const loggerWrapper: NLUEngine.Logger = {
-    debug: (msg: string) => logger.debug(msg),
-    info: (msg: string) => logger.info(msg),
-    warning: (msg: string, err?: Error) => (err ? logger.attachError(err).warn(msg) : logger.warn(msg)),
-    error: (msg: string, err?: Error) => (err ? logger.attachError(err).error(msg) : logger.error(msg))
-  }
-
-  try {
-    const { ducklingEnabled, ducklingURL, modelCacheSize, languageSources, legacyElection } = options
-    const config: NLUEngine.Config = {
-      languageSources,
-      ducklingEnabled,
-      ducklingURL,
-      modelCacheSize,
-      legacyElection
-    }
-
-    const engine = await NLUEngine.makeEngine(config, loggerWrapper)
-    return engine
-  } catch (err) {
-    // TODO: Make lang provider throw if it can't connect.
-    logger
-      .attachError(err)
-      .error(
-        'There was an error while initializing Engine tools. Check out the connection to your language and Duckling server.'
-      )
-    process.exit(1)
-  }
-}
+import { makeEngine } from './make-engine'
 
 export default async function (cliOptions: CommandLineOptions, version: string) {
   const { options, source: configSource } = await getConfig(cliOptions)
@@ -50,10 +19,8 @@ export default async function (cliOptions: CommandLineOptions, version: string) 
   })
 
   const launcherLogger = Logger.sub('Launcher')
-  // Launcher always display
   launcherLogger.configure({
-    level: Math.max(options.verbose, LoggerLevel.Info),
-    filters: ['']
+    minLevel: LoggerLevel.Info // Launcher always display
   })
 
   for (const dir of ['./pre-trained', './stop-words']) {

--- a/packages/nlu/src/nlu-server/make-engine.ts
+++ b/packages/nlu/src/nlu-server/make-engine.ts
@@ -1,0 +1,35 @@
+import _ from 'lodash'
+import * as NLUEngine from '../engine'
+import { ILogger } from '../utils/logger/typings'
+import { StanOptions } from './config'
+
+export const makeEngine = async (options: StanOptions, logger: ILogger) => {
+  const loggerWrapper: NLUEngine.Logger = {
+    debug: (msg: string) => logger.debug(msg),
+    info: (msg: string) => logger.info(msg),
+    warning: (msg: string, err?: Error) => (err ? logger.attachError(err).warn(msg) : logger.warn(msg)),
+    error: (msg: string, err?: Error) => (err ? logger.attachError(err).error(msg) : logger.error(msg))
+  }
+
+  try {
+    const { ducklingEnabled, ducklingURL, modelCacheSize, languageSources, legacyElection } = options
+    const config: NLUEngine.Config = {
+      languageSources,
+      ducklingEnabled,
+      ducklingURL,
+      modelCacheSize,
+      legacyElection
+    }
+
+    const engine = await NLUEngine.makeEngine(config, loggerWrapper)
+    return engine
+  } catch (err) {
+    // TODO: Make lang provider throw if it can't connect.
+    logger
+      .attachError(err)
+      .error(
+        'There was an error while initializing Engine tools. Check out the connection to your language and Duckling server.'
+      )
+    process.exit(1)
+  }
+}

--- a/packages/nlu/src/utils/logger/index.ts
+++ b/packages/nlu/src/utils/logger/index.ts
@@ -10,6 +10,7 @@ export const centerText = (text: string, width: number, indent: number = 0) => {
 
 export const defaultConfig: LoggerConfig = {
   level: LoggerLevel.Info,
+  minLevel: undefined,
   timeFormat: 'L HH:mm:ss.SSS',
   namespaceDelimiter: ':',
   colors: {
@@ -22,7 +23,7 @@ export const defaultConfig: LoggerConfig = {
   formatter: new ConsoleFormatter({ indent: !!process.env.INDENT_LOGS }),
   transports: [new ConsoleTransport()],
   indent: false,
-  filters: ['']
+  filters: undefined // show all logs
 }
 
 class Logger implements ILogger {

--- a/packages/nlu/src/utils/logger/transports/console.ts
+++ b/packages/nlu/src/utils/logger/transports/console.ts
@@ -14,9 +14,15 @@ export const conforms = (namespace: string, rule: string, delimiter: string) => 
 
 export class ConsoleTransport implements LogTransporter {
   send(config: LoggerConfig, entry: FormattedLogEntry) {
+    if (config.minLevel && entry.level <= config.minLevel) {
+      this._log(entry.formatted)
+      return
+    }
+
     if (entry.level <= config.level) {
-      if (!config.filters.length) {
+      if (!config.filters) {
         this._log(entry.formatted)
+        return
       }
 
       for (const rule of config.filters) {

--- a/packages/nlu/src/utils/logger/typings.ts
+++ b/packages/nlu/src/utils/logger/typings.ts
@@ -39,11 +39,12 @@ export interface LogTransporter {
 
 export interface LoggerConfig {
   level: LoggerLevel
+  minLevel: LoggerLevel | undefined // if defined, allows to bypass filters
   formatter: LogEntryFormatter
   transports: LogTransporter[]
   timeFormat: string // moment time format
   namespaceDelimiter: string
   colors: { [level: number]: string }
   indent: boolean
-  filters: string[]
+  filters: string[] | undefined
 }


### PR DESCRIPTION
Basically, if verbose is 4, you have to specify `--log-filter Launcher` to get the debug of filters.

This is done by 2 things:
1. log filter can be `undefined` which results in no filters being applied
2. There is a logger config called `minLevel` which allows to bypass log filters if level is reached. This field is used by Launcher logger.

I took the opportunity to fix a changelog mess I did earlier today + change the env variable `STAN_JSON_CONFIG` by `NLU_SERVER_CONFIG`. This env variable is meant to be used only by the main botpress server anyway.