### PR TITLE
feat(logs): suggestion for debug logs

### DIFF
--- a/packages/nlu/package.json
+++ b/packages/nlu/package.json
@@ -32,6 +32,7 @@
     "chalk": "^2.4.2",
     "chokidar": "^2.1.5",
     "cors": "^2.8.5",
+    "debug": "^4.3.1",
     "diff": "^4.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.1",

--- a/packages/nlu/src/engine/engine/language/language-provider.ts
+++ b/packages/nlu/src/engine/engine/language/language-provider.ts
@@ -11,14 +11,13 @@ import ms from 'ms'
 import path from 'path'
 import semver from 'semver'
 import { Health } from '../../../typings_v1'
-import Logger from '../../../utils/logger'
 import { LanguageSource, Logger as ILogger } from '../../typings'
 
 import { setSimilarity, vocabNGram } from '../tools/strings'
 import { isSpace, processUtteranceTokens, restoreOriginalUtteranceCasing } from '../tools/token-utils'
 import { Gateway, LangServerInfo, LangsGateway, LanguageProvider, SeededLodashProvider } from '../typings'
 
-const logger = Logger.sub('lang')
+const debug = DEBUG('lang')
 
 const MAX_PAYLOAD_SIZE = 150 * 1024 // 150kb
 const JUNK_VOCAB_SIZE = 500
@@ -63,7 +62,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
 
   private addProvider(lang: string, source: LanguageSource, client: AxiosInstance) {
     this.langs[lang] = [...(this.langs[lang] || []), { source, client, errors: 0, disabledUntil: undefined }]
-    logger.debug(`[${lang.toUpperCase()}] Language Provider added %o`, source)
+    debug(`[${lang.toUpperCase()}] Language Provider added %o`, source)
   }
 
   async initialize(
@@ -256,9 +255,9 @@ export class RemoteLanguageProvider implements LanguageProvider {
     try {
       await fse.ensureFile(this._tokensCachePath)
       await fse.writeJson(this._tokensCachePath, this._tokensCache.dump())
-      logger.debug('tokens cache updated at: %s', this._tokensCachePath)
+      debug('tokens cache updated at: %s', this._tokensCachePath)
     } catch (err) {
-      logger.debug('could not persist tokens cache, error: %s', err.message)
+      debug('could not persist tokens cache, error: %s', err.message)
       this._cacheDumpDisabled = true
     }
   }
@@ -270,7 +269,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
         this._tokensCache.load(dump)
       }
     } catch (err) {
-      logger.debug('could not restore tokens cache, error: %s', err.message)
+      debug('could not restore tokens cache, error: %s', err.message)
     }
   }
 
@@ -278,9 +277,9 @@ export class RemoteLanguageProvider implements LanguageProvider {
     try {
       await fse.ensureFile(this._vectorsCachePath)
       await fse.writeJSON(this._vectorsCachePath, this._vectorsCache.dump())
-      logger.debug('vectors cache updated at: %s', this._vectorsCachePath)
+      debug('vectors cache updated at: %s', this._vectorsCachePath)
     } catch (err) {
-      logger.debug('could not persist vectors cache, error: %s', err.message)
+      debug('could not persist vectors cache, error: %s', err.message)
       this._cacheDumpDisabled = true
     }
   }
@@ -295,7 +294,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
         }
       }
     } catch (err) {
-      logger.debug('could not restore vectors cache, error: %s', err.message)
+      debug('could not restore vectors cache, error: %s', err.message)
     }
   }
 
@@ -303,9 +302,9 @@ export class RemoteLanguageProvider implements LanguageProvider {
     try {
       await fse.ensureFile(this._junkwordsCachePath)
       await fse.writeJSON(this._junkwordsCachePath, this._junkwordsCache.dump())
-      logger.debug('junk words cache updated at: %s', this._junkwordsCache)
+      debug('junk words cache updated at: %s', this._junkwordsCache)
     } catch (err) {
-      logger.debug('could not persist junk cache, error: %s', err.message)
+      debug('could not persist junk cache, error: %s', err.message)
       this._cacheDumpDisabled = true
     }
   }
@@ -317,7 +316,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
         this._vectorsCache.load(dump)
       }
     } catch (err) {
-      logger.debug('could not restore junk cache, error: %s', err.message)
+      debug('could not restore junk cache, error: %s', err.message)
     }
   }
 
@@ -346,7 +345,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
 
         return data
       } catch (err) {
-        logger.debug('error from language server', {
+        debug('error from language server', {
           message: err.message,
           code: err.code,
           status: err.status,
@@ -359,7 +358,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
             .add(provider.errors++, 'seconds')
             .toDate()
 
-          logger.debug('disabled temporarily source', {
+          debug('disabled temporarily source', {
             source: provider.source,
             err: err.message,
             errors: provider.errors,

--- a/packages/nlu/src/global.d.ts
+++ b/packages/nlu/src/global.d.ts
@@ -5,7 +5,25 @@ declare namespace NodeJS {
     PROJECT_LOCATION: string
     pkg: any
   }
+
+  export interface Global {
+    DEBUG: IDebug
+    printLog(args: any[]): void
+  }
 }
 
 declare var process: NodeJS.Process
 declare var global: NodeJS.Global
+
+interface IDebugInstance {
+  readonly enabled: boolean
+
+  (msg: string, extra?: any): void
+  sub(namespace: string): IDebugInstance
+}
+
+interface IDebug {
+  (module: string, botId?: string): IDebugInstance
+}
+
+declare var DEBUG: IDebug

--- a/packages/nlu/src/index.ts
+++ b/packages/nlu/src/index.ts
@@ -1,4 +1,6 @@
 // eslint-disable-next-line import/order
+import './utils/debug'
+// eslint-disable-next-line import/order
 import Logger from './utils/logger'
 import path from 'path'
 import yargs from 'yargs'

--- a/packages/nlu/src/lang-server/service/model-download.ts
+++ b/packages/nlu/src/lang-server/service/model-download.ts
@@ -15,6 +15,7 @@ export interface DownloadableModel {
 }
 
 const logger = Logger.sub('lang').sub('download')
+const debug = DEBUG('lang:download')
 
 export type DownloadStatus = 'pending' | 'downloading' | 'loading' | 'errored' | 'done'
 
@@ -57,7 +58,7 @@ export default class ModelDownload {
 
   private async _downloadNext() {
     const modelToDownload = this.models.shift() as DownloadableModel
-    logger.debug(`Started to download ${modelToDownload.language} ${modelToDownload.type} model`)
+    debug(`Started to download ${modelToDownload.language} ${modelToDownload.type} model`)
 
     const { data, headers } = await axios.get(modelToDownload.remoteUrl, {
       responseType: 'stream',
@@ -117,21 +118,21 @@ export default class ModelDownload {
       fse.unlinkSync(tmpPath)
     }
 
-    logger.debug('deleting model %o', { path: tmpPath, type: model.type, lang: model.language })
+    debug('deleting model %o', { path: tmpPath, type: model.type, lang: model.language })
   }
 
   private async _makeModelAvailable(model: DownloadableModel) {
     const filePath = this.getFilePath(model) as string
     const tmpPath = `${filePath}.tmp`
     if (fse.existsSync(filePath)) {
-      logger.debug('removing existing model at %s', filePath)
+      debug('removing existing model at %s', filePath)
       fse.unlinkSync(filePath)
     }
 
     try {
       await Bluebird.fromCallback((cb) => fse.rename(tmpPath, filePath, cb))
     } catch (err) {
-      logger.debug('could not rename downloaded file %s', filePath)
+      debug('could not rename downloaded file %s', filePath)
       await Bluebird.fromCallback((cb) => fse.move(tmpPath, filePath, cb))
     }
   }

--- a/packages/nlu/src/nlu-server/index.ts
+++ b/packages/nlu/src/nlu-server/index.ts
@@ -14,9 +14,16 @@ export default async function (cliOptions: CommandLineOptions, version: string) 
   const { options, source: configSource } = await getConfig(cliOptions)
 
   Logger.configure({
-    level: Number(options.verbose) !== NaN ? Number(options.verbose) : LoggerLevel.Info,
-    filters: options.logFilter
+    level: Number(options.verbose) !== NaN ? Number(options.verbose) : LoggerLevel.Info
   })
+
+  const debugLogger = Logger.sub('')
+  global.printLog = (args) => {
+    const message = args[0]
+    const rest = args.slice(1)
+
+    debugLogger.debug(message.trim(), rest)
+  }
 
   const launcherLogger = Logger.sub('Launcher')
   launcherLogger.configure({

--- a/packages/nlu/src/nlu-server/model-repo.ts
+++ b/packages/nlu/src/nlu-server/model-repo.ts
@@ -15,7 +15,6 @@ import {
   ScopedGhostService,
   MemoryObjectCache
 } from '../utils/ghost'
-import Logger from '../utils/logger'
 import { ILogger } from '../utils/logger/typings'
 
 interface FSDriver {
@@ -43,7 +42,7 @@ interface PruneOptions extends ModelOwnershipOptions {
 const MODELS_DIR = './models'
 const MODELS_EXT = 'model'
 
-const logger = Logger.sub('model-repo')
+const modelRepoDebug = DEBUG('api:model-repo')
 
 // TODO: add a customizable modelDir
 const defaultOtpions: ModelRepoOptions = {
@@ -69,7 +68,7 @@ export class ModelRepository {
   }
 
   async initialize() {
-    logger.debug('Model service initializing...')
+    modelRepoDebug('Model service initializing...')
     if (this.options.driver === 'db') {
       await this._db.initialize('postgres', this.options.dbURL)
     }

--- a/packages/nlu/src/utils/debug.ts
+++ b/packages/nlu/src/utils/debug.ts
@@ -1,0 +1,38 @@
+const debug = require('debug')
+
+const available = {}
+
+export const Debug = (mod: string, base = 'bp:nlu') => {
+  const namespace = base + ':' + mod
+  available[namespace] = true
+
+  const instance = debug(base).extend(mod)
+  instance.sub = (mod) => Debug(mod, namespace)
+
+  return instance
+}
+
+export const getDebugScopes = () => {
+  const status = {}
+  Object.keys(available).forEach((key) => (status[key] = debug.enabled(key)))
+  return status
+}
+
+export const getDebugString = (): string => {
+  return Object.keys(available)
+    .filter((key) => debug.enabled(key))
+    .join(',')
+}
+
+export const setDebugScopes = (scopes: string) => {
+  debug.disable()
+  debug.enable(scopes)
+
+  scopes.split(',').forEach((key) => (available[key] = debug.enabled(key)))
+}
+
+debug.log = function (...args) {
+  global.printLog(args)
+}
+
+global.DEBUG = Debug

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,7 +3060,7 @@ debug@^3.1.0:
 
 debug@^4.0.1, debug@^4.3.1:
   version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"


### PR DESCRIPTION
Hey guys, I took a look at the logging of the application and I have some points i'd like to discuss. The "logFilter" is not a good idea, currently if you filter a type of log and you have an error, it may go unnoticed for a long time and may disrupt the investigation of an issue.

These type of log should always be displayed, whatever the "verbosity" of the app is:
- Info
- Warn
- Error

All other informational logs are considered "debug", thus we should definitely stick with the "Debug" library like almost every other projects. I would suggest removing properties "verbose" and "logFilter", and stick with the debug environment variable to handle this. For the CLI, it can use the same format as `debug.json` on the server

If we go that way, we would have all nlu debug scopes available on the admin panel, and we could toggle them easily, and they will be automatically restored when the server is restarted: 

![image](https://user-images.githubusercontent.com/42552874/121401264-85766080-c926-11eb-968a-d2d501ea2c96.png)

The result would be similar to what we have on BP, but it will be clear that it's related to the NLU: 

![image](https://user-images.githubusercontent.com/42552874/121401095-54962b80-c926-11eb-9324-c81a75d3eb7d.png)


Here's the implantation on the server's side: https://github.com/botpress/botpress/pull/5084

I've only touched the logging on package `nlu`, it could also be changed on the lang server