### PR TITLE
feat(e2e): configurable NLU server endpoint

### DIFF
--- a/packages/bitfan/readme.md
+++ b/packages/bitfan/readme.md
@@ -100,9 +100,9 @@ async function main() {
     lang: 'en'
   }))
 
-  const stanEndpoint = 'http://localhost:3200'
+  const nluServerEndpoint = process.env.NLU_SERVER_ENDPOINT ?? 'http://localhost:3200'
   const password = '123456'
-  const engine = bitfan.engines.makeBpIntentEngine(stanEndpoint, password)
+  const engine = bitfan.engines.makeBpIntentEngine(nluServerEndpoint, password)
 
   const metrics: Metric<'intent'> = [
     bitfan.metrics.accuracy,

--- a/packages/bitfan/src/services/bp-provider/stan-provider.ts
+++ b/packages/bitfan/src/services/bp-provider/stan-provider.ts
@@ -9,11 +9,11 @@ const POLLING_INTERVAL = 500
 export class StanProvider {
   private _modelId: string | undefined
 
-  constructor(private _stanEndpoint: string = 'http://localhost:3200', password = '') {}
+  constructor(private _nluServerEndpoint: string = 'http://localhost:3200', password = '') {}
 
   public async getVersion(): Promise<{ version: string } | undefined> {
     try {
-      const { data } = await axios.get(`${this._stanEndpoint}/info`) // just to see if breaking
+      const { data } = await axios.get(`${this._nluServerEndpoint}/info`) // just to see if breaking
       return data
     } catch (err) {
       this._mapErrorAndRethrow('INFO', err)
@@ -21,7 +21,7 @@ export class StanProvider {
   }
 
   private async _getTrainingStatus(modelId: string): Promise<TrainingSession> {
-    const { data } = await axios.get(`${this._stanEndpoint}/train/${modelId}`, {
+    const { data } = await axios.get(`${this._nluServerEndpoint}/train/${modelId}`, {
       params: {}
     })
     return data.session
@@ -49,7 +49,7 @@ export class StanProvider {
     const inputWithPassword = { ...trainInput }
 
     try {
-      const { data } = await axios.post(`${this._stanEndpoint}/train`, inputWithPassword)
+      const { data } = await axios.post(`${this._nluServerEndpoint}/train`, inputWithPassword)
 
       const { modelId } = data
       this._modelId = modelId
@@ -65,7 +65,7 @@ export class StanProvider {
     success: boolean
     predictions: PredictOutput[]
   }> {
-    const { data } = await axios.post(`${this._stanEndpoint}/predict/${this._modelId}`, {
+    const { data } = await axios.post(`${this._nluServerEndpoint}/predict/${this._modelId}`, {
       utterances
     })
     return data

--- a/packages/e2e/src/tests/bpds-intents.ts
+++ b/packages/e2e/src/tests/bpds-intents.ts
@@ -42,9 +42,9 @@ export default function (bitfan) {
         await makeProblem('bpds A fewshot-fr', 'fr', 'A-fewshot-train', 'A-test')
       ]
 
-      const stanEndpoint = 'http://localhost:3200'
+      const nluServerEndpoint = process.env.NLU_SERVER_ENDPOINT ?? 'http://localhost:3200'
       const password = '123456'
-      const engine = bitfan.engines.makeBpIntentEngine(stanEndpoint, password)
+      const engine = bitfan.engines.makeBpIntentEngine(nluServerEndpoint, password)
 
       const solution = {
         name: 'bpds intent',

--- a/packages/e2e/src/tests/bpds-slots.ts
+++ b/packages/e2e/src/tests/bpds-slots.ts
@@ -47,9 +47,9 @@ export default function (bitfan) {
       const makeProblem = problemMaker(bitfan)
       const problems = await Bluebird.map(allTopics, makeProblem)
 
-      const stanEndpoint = 'http://localhost:3200'
+      const nluServerEndpoint = process.env.NLU_SERVER_ENDPOINT ?? 'http://localhost:3200'
       const password = '123456'
-      const engine = bitfan.engines.makeBpSlotEngine(stanEndpoint, password)
+      const engine = bitfan.engines.makeBpSlotEngine(nluServerEndpoint, password)
 
       const solution = {
         name: 'bpds slot',

--- a/packages/e2e/src/tests/bpds-spell.ts
+++ b/packages/e2e/src/tests/bpds-spell.ts
@@ -5,9 +5,9 @@ export default function (bitfan) {
     name: 'bpds-spell',
 
     computePerformance: async () => {
-      const stanEndpoint = 'http://localhost:3200'
+      const nluServerEndpoint = process.env.NLU_SERVER_ENDPOINT ?? 'http://localhost:3200'
       const password = '123456'
-      const engine = bitfan.engines.makeBpSpellEngine(stanEndpoint, password)
+      const engine = bitfan.engines.makeBpSpellEngine(nluServerEndpoint, password)
 
       const trainFileDef = {
         name: 'A-train',

--- a/packages/e2e/src/tests/clinc-intents.ts
+++ b/packages/e2e/src/tests/clinc-intents.ts
@@ -30,9 +30,9 @@ export default function (bitfan) {
     name: 'clinc150',
 
     computePerformance: async () => {
-      const stanEndpoint = 'http://localhost:3200'
+      const nluServerEndpoint = process.env.NLU_SERVER_ENDPOINT ?? 'http://localhost:3200'
       const password = '123456'
-      const engine = bitfan.engines.makeBpIntentEngine(stanEndpoint, password)
+      const engine = bitfan.engines.makeBpIntentEngine(nluServerEndpoint, password)
 
       const makeProblem = problemMaker(bitfan)
 


### PR DESCRIPTION
This allows running tests against a remote NLU server, or a NLU server that is running locally on another port than 3200