### PR TITLE
fix: exact matcher now works even with different entities

### DIFF
--- a/packages/nlu/package.json
+++ b/packages/nlu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nlu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Botpress NLU main package",
   "main": "./dist/index.js",
   "author": "Botpress, Inc.",

--- a/packages/nlu/src/engine/engine/intents/exact-intent-classifier.ts
+++ b/packages/nlu/src/engine/engine/intents/exact-intent-classifier.ts
@@ -16,8 +16,7 @@ type ExactMatchIndex = _.Dictionary<{ intent: string }>
 const EXACT_MATCH_STR_OPTIONS: UtteranceToStringOptions = {
   lowerCase: true,
   onlyWords: true,
-  slots: 'keep-value', // slot extraction is done in || with intent prediction
-  entities: 'keep-name'
+  strategy: 'replace-entity-name'
 }
 
 const schemaKeys: Record<keyof Model, Joi.AnySchema> = {

--- a/packages/nlu/src/engine/engine/predict-pipeline.ts
+++ b/packages/nlu/src/engine/engine/predict-pipeline.ts
@@ -1,7 +1,5 @@
 import Bluebird from 'bluebird'
 import _ from 'lodash'
-import { MLToolkit } from '../ml/typings'
-
 import {
   EntityPrediction,
   SlotPrediction,
@@ -9,6 +7,7 @@ import {
   IntentPrediction as StanIntentPrediction,
   PredictOutput
 } from '../../typings_v1'
+import { MLToolkit } from '../ml/typings'
 
 import { CustomEntityExtractor } from './entities/custom-extractor'
 import { IntentPrediction, IntentPredictions, NoneableIntentPredictions } from './intents/intent-classifier'
@@ -161,7 +160,7 @@ async function extractSlots(input: IntentStep, predictors: Predictors): Promise<
 
 async function spellCheck(input: SlotStep, predictors: Predictors, tools: Tools): Promise<SpellStep> {
   const spellChecker = makeSpellChecker(predictors.vocab, input.languageCode, tools)
-  const spellChecked = await spellChecker(input.utterance.toString({ entities: 'keep-default', slots: 'keep-default' }))
+  const spellChecked = await spellChecker(input.utterance.toString({ strategy: 'keep-token' }))
   return {
     ...input,
     spellChecked

--- a/packages/nlu/src/engine/engine/slots/slot-tagger.ts
+++ b/packages/nlu/src/engine/engine/slots/slot-tagger.ts
@@ -92,7 +92,7 @@ export function makeExtractedSlots(
 
       if (shouldConcatWithPrev && last) {
         const newEnd = token.offset + token.value.length
-        const newSource = utterance.toString({ entities: 'keep-default' }).slice(last.start, newEnd) // we use slice in case tokens are space split
+        const newSource = utterance.toString({ strategy: 'keep-token' }).slice(last.start, newEnd) // we use slice in case tokens are space split
         last.slot.source = newSource
         last.slot.value = newSource
         last.end = newEnd

--- a/packages/nlu/src/engine/engine/utterance/utterance.test.ts
+++ b/packages/nlu/src/engine/engine/utterance/utterance.test.ts
@@ -358,9 +358,13 @@ describe('UtteranceClass', () => {
       expect(u.toString({ ...defaultOptions, strategy: 'replace-slot-name' })).toEqual(
         `This IS a ${slot.name} withFire`
       )
-      expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual(str)
-      expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual(`This IS a ${entity.value} withFire`)
-      expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual(`This IS a ${entity.type} withFire`)
+      expect(u.toString({ ...defaultOptions, strategy: 'keep-token' })).toEqual(str)
+      expect(u.toString({ ...defaultOptions, strategy: 'replace-entity-value' })).toEqual(
+        `This IS a ${entity.value} withFire`
+      )
+      expect(u.toString({ ...defaultOptions, strategy: 'replace-entity-name' })).toEqual(
+        `This IS a ${entity.type} withFire`
+      )
       expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual('This IS a  withFire')
     })
   })

--- a/packages/nlu/src/engine/engine/utterance/utterance.test.ts
+++ b/packages/nlu/src/engine/engine/utterance/utterance.test.ts
@@ -285,12 +285,11 @@ describe('UtteranceClass', () => {
 
     // @ts-ignore
     const fakePOS = tokens.map((t) => 'POS') as POSClass[]
-    const defaultOptions = {
-      entities: 'keep-default',
-      slots: 'keep-value',
+    const defaultOptions: UtteranceToStringOptions = {
+      strategy: 'keep-token',
       onlyWords: false,
       lowerCase: false
-    } as UtteranceToStringOptions
+    }
 
     test('format options', () => {
       const u = new Utterance(tokens, fakeVectors, fakePOS, 'en')
@@ -313,8 +312,10 @@ describe('UtteranceClass', () => {
       u.tagSlot(slot as ExtractedSlot, 10, 19)
 
       expect(u.toString(defaultOptions)).toEqual(str)
-      expect(u.toString({ ...defaultOptions, slots: 'keep-name' })).toEqual(`This IS a ${slot.name} withFire`)
-      expect(u.toString({ ...defaultOptions, slots: 'ignore' })).toEqual('This IS a  withFire')
+      expect(u.toString({ ...defaultOptions, strategy: 'replace-slot-name' })).toEqual(
+        `This IS a ${slot.name} withFire`
+      )
+      expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual('This IS a  withFire')
     })
 
     test('entities options', () => {
@@ -328,9 +329,13 @@ describe('UtteranceClass', () => {
       u.tagEntity(entity, 10, 19)
 
       expect(u.toString(defaultOptions)).toEqual(str)
-      expect(u.toString({ ...defaultOptions, entities: 'keep-value' })).toEqual(`This IS a ${entity.value} withFire`)
-      expect(u.toString({ ...defaultOptions, entities: 'keep-name' })).toEqual(`This IS a ${entity.type} withFire`)
-      expect(u.toString({ ...defaultOptions, entities: 'ignore' })).toEqual('This IS a  withFire')
+      expect(u.toString({ ...defaultOptions, strategy: 'replace-entity-value' })).toEqual(
+        `This IS a ${entity.value} withFire`
+      )
+      expect(u.toString({ ...defaultOptions, strategy: 'replace-entity-name' })).toEqual(
+        `This IS a ${entity.type} withFire`
+      )
+      expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual('This IS a  withFire')
     })
 
     test('entities and slots options', () => {
@@ -349,18 +354,14 @@ describe('UtteranceClass', () => {
       }
       u.tagEntity(entity, 10, 19)
 
-      expect(u.toString({ ...defaultOptions, slots: 'keep-value', entities: 'keep-value' })).toEqual(str)
-      expect(u.toString({ ...defaultOptions, slots: 'keep-name', entities: 'keep-value' })).toEqual(
+      expect(u.toString({ ...defaultOptions, strategy: 'keep-token' })).toEqual(str)
+      expect(u.toString({ ...defaultOptions, strategy: 'replace-slot-name' })).toEqual(
         `This IS a ${slot.name} withFire`
       )
-      expect(u.toString({ ...defaultOptions, slots: 'ignore', entities: 'keep-default' })).toEqual(str)
-      expect(u.toString({ ...defaultOptions, slots: 'ignore', entities: 'keep-value' })).toEqual(
-        `This IS a ${entity.value} withFire`
-      )
-      expect(u.toString({ ...defaultOptions, slots: 'ignore', entities: 'keep-name' })).toEqual(
-        `This IS a ${entity.type} withFire`
-      )
-      expect(u.toString({ ...defaultOptions, slots: 'ignore', entities: 'ignore' })).toEqual('This IS a  withFire')
+      expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual(str)
+      expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual(`This IS a ${entity.value} withFire`)
+      expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual(`This IS a ${entity.type} withFire`)
+      expect(u.toString({ ...defaultOptions, strategy: 'ignore' })).toEqual('This IS a  withFire')
     })
   })
 


### PR DESCRIPTION
This PR should fix [this issue](https://github.com/botpress/botpress/issues/4872) 

Previously if a token had both a slot and an entity, and we had option `slot: 'keep-value'`, then the entity `if` clause was bypassed.

With these new options, slot and entity replacement are mutually exclusive.