### PR TITLE
chore(nlu-client): no need for appid when calling the info route

### DIFF
--- a/packages/bitfan/src/bitfan.d.ts
+++ b/packages/bitfan/src/bitfan.d.ts
@@ -84,10 +84,10 @@ export namespace visualisation {
 }
 
 export namespace engines {
-  export const makeBpIntentEngine: (bpEndpoint: string, password: string) => Engine<'intent'>
-  export const makeBpTopicEngine: (bpEndpoint: string, password: string) => Engine<'topic'>
-  export const makeBpSlotEngine: (bpEndpoint: string, password: string) => Engine<'slot'>
-  export const makeBpSpellEngine: (bpEndpoint: string, password: string) => UnsupervisedEngine<'spell'>
+  export const makeBpIntentEngine: (bpEndpoint: string) => Engine<'intent'>
+  export const makeBpTopicEngine: (bpEndpoint: string) => Engine<'topic'>
+  export const makeBpSlotEngine: (bpEndpoint: string) => Engine<'slot'>
+  export const makeBpSpellEngine: (bpEndpoint: string) => UnsupervisedEngine<'spell'>
 }
 
 export namespace sampling {

--- a/packages/bitfan/src/builtin/engines/intent.ts
+++ b/packages/bitfan/src/builtin/engines/intent.ts
@@ -12,8 +12,8 @@ const BATCH_SIZE = 10
 export class BpIntentEngine implements sdk.Engine<'intent'> {
   private _stanProvider: StanProvider
 
-  constructor(bpEndpoint?: string, password?: string) {
-    this._stanProvider = new StanProvider(bpEndpoint, password)
+  constructor(bpEndpoint?: string) {
+    this._stanProvider = new StanProvider(bpEndpoint)
   }
 
   train(trainSet: sdk.DataSet<'intent'>, seed: number, progress: sdk.ProgressCb) {

--- a/packages/bitfan/src/builtin/engines/slot.ts
+++ b/packages/bitfan/src/builtin/engines/slot.ts
@@ -12,8 +12,8 @@ const BATCH_SIZE = 10
 export class BpSlotEngine implements sdk.Engine<'slot'> {
   private _stanProvider: StanProvider
 
-  constructor(bpEndpoint?: string, password?: string) {
-    this._stanProvider = new StanProvider(bpEndpoint, password)
+  constructor(bpEndpoint?: string) {
+    this._stanProvider = new StanProvider(bpEndpoint)
   }
 
   train(trainSet: sdk.DataSet<'slot'>, seed: number, progress: sdk.ProgressCb) {

--- a/packages/bitfan/src/builtin/engines/spell.ts
+++ b/packages/bitfan/src/builtin/engines/spell.ts
@@ -12,8 +12,8 @@ const BATCH_SIZE = 10
 export class BpSpellingEngine implements sdk.UnsupervisedEngine<'spell'> {
   private _stanProvider: StanProvider
 
-  constructor(bpEndpoint?: string, password?: string) {
-    this._stanProvider = new StanProvider(bpEndpoint, password)
+  constructor(bpEndpoint?: string) {
+    this._stanProvider = new StanProvider(bpEndpoint)
   }
 
   train(corpus: sdk.Document[], seed: number, progress: sdk.ProgressCb) {

--- a/packages/bitfan/src/builtin/engines/topic.ts
+++ b/packages/bitfan/src/builtin/engines/topic.ts
@@ -10,7 +10,7 @@ const BATCH_SIZE = 10
 export class BpTopicEngine implements sdk.Engine<'topic'> {
   private _stanProvider: StanProvider
 
-  constructor(bpEndpoint: string, password: string) {
+  constructor(bpEndpoint: string) {
     this._stanProvider = new StanProvider(bpEndpoint)
   }
 

--- a/packages/bitfan/src/index.ts
+++ b/packages/bitfan/src/index.ts
@@ -97,10 +97,10 @@ const impl: typeof sdk = {
   },
 
   engines: {
-    makeBpTopicEngine: (bpEndpoint: string, password: string) => new BpTopicEngine(bpEndpoint, password),
-    makeBpIntentEngine: (bpEndpoint: string, password: string) => new BpIntentEngine(bpEndpoint, password),
-    makeBpSlotEngine: (bpEndpoint: string, password: string) => new BpSlotEngine(bpEndpoint, password),
-    makeBpSpellEngine: (bpEndpoint: string, password: string) => new BpSpellingEngine(bpEndpoint, password)
+    makeBpTopicEngine: (bpEndpoint: string) => new BpTopicEngine(bpEndpoint),
+    makeBpIntentEngine: (bpEndpoint: string) => new BpIntentEngine(bpEndpoint),
+    makeBpSlotEngine: (bpEndpoint: string) => new BpSlotEngine(bpEndpoint),
+    makeBpSpellEngine: (bpEndpoint: string) => new BpSpellingEngine(bpEndpoint)
   },
 
   tables: {

--- a/packages/bitfan/src/services/bp-provider/stan-provider.ts
+++ b/packages/bitfan/src/services/bp-provider/stan-provider.ts
@@ -10,12 +10,12 @@ export class StanProvider {
   private _modelId: string | undefined
   private _client: Client
 
-  constructor(nluServerEndpoint: string = 'http://localhost:3200', password = '') {
-    this._client = new Client(nluServerEndpoint, APP_ID, password)
+  constructor(nluServerEndpoint: string = 'http://localhost:3200') {
+    this._client = new Client(nluServerEndpoint)
   }
 
   private async _getTrainingStatus(modelId: string): Promise<TrainingState> {
-    const data = await this._client.getTrainingStatus(modelId)
+    const data = await this._client.getTrainingStatus(APP_ID, modelId)
     if (data.success) {
       return data.session
     }
@@ -46,7 +46,7 @@ export class StanProvider {
       .uniq()
       .value()
 
-    const data = await this._client.startTraining({
+    const data = await this._client.startTraining(APP_ID, {
       language: trainInput.language,
       contexts,
       intents: trainInput.intents,
@@ -63,7 +63,7 @@ export class StanProvider {
   }
 
   public async predict(utterances: string[]): Promise<PredictOutput[]> {
-    const predOutput = await this._client.predict(this._modelId ?? '', { utterances })
+    const predOutput = await this._client.predict(APP_ID, this._modelId ?? '', { utterances })
     if (!predOutput.success) {
       throw new Error(`An error occured at prediction: ${predOutput.error}.`)
     }

--- a/packages/nlu-client/src/client.ts
+++ b/packages/nlu-client/src/client.ts
@@ -20,11 +20,8 @@ import {
 export class NLUClient implements IClient {
   protected _client: AxiosInstance
 
-  constructor(protected _endpoint: string, protected _appId: string) {
-    this._client = axios.create({
-      baseURL: this._endpoint,
-      headers: { 'X-App-Id': _appId }
-    })
+  constructor(protected _endpoint: string) {
+    this._client = axios.create({ baseURL: this._endpoint })
   }
 
   public async getInfo(): Promise<InfoResponseBody | ErrorResponse> {
@@ -34,64 +31,82 @@ export class NLUClient implements IClient {
     })
   }
 
-  public async startTraining(trainRequestBody: TrainRequestBody): Promise<TrainResponseBody | ErrorResponse> {
+  public async startTraining(
+    appId: string,
+    trainRequestBody: TrainRequestBody
+  ): Promise<TrainResponseBody | ErrorResponse> {
     return this._wrapWithTryCatch(async () => {
-      const { data } = await this._client.post('train', trainRequestBody)
+      const headers = this._appIdHeader(appId)
+      const { data } = await this._client.post('train', trainRequestBody, { headers })
       return data
     })
   }
 
-  public async getTrainingStatus(modelId: string): Promise<TrainProgressResponseBody | ErrorResponse> {
+  public async getTrainingStatus(appId: string, modelId: string): Promise<TrainProgressResponseBody | ErrorResponse> {
     return this._wrapWithTryCatch(async () => {
+      const headers = this._appIdHeader(appId)
       const endpoint = `train/${modelId}`
-      const { data } = await this._client.get(endpoint)
+      const { data } = await this._client.get(endpoint, { headers })
       return data
     })
   }
 
-  public async cancelTraining(modelId: string): Promise<SuccessReponse | ErrorResponse> {
+  public async cancelTraining(appId: string, modelId: string): Promise<SuccessReponse | ErrorResponse> {
     return this._wrapWithTryCatch(async () => {
+      const headers = this._appIdHeader(appId)
       const endpoint = `train/${modelId}/cancel`
-      const { data } = await this._client.post(endpoint)
+      const { data } = await this._client.post(endpoint, {}, { headers })
       return data
     })
   }
 
-  public async listModels(): Promise<ListModelsResponseBody | ErrorResponse> {
+  public async listModels(appId: string): Promise<ListModelsResponseBody | ErrorResponse> {
     return this._wrapWithTryCatch(async () => {
-      const endpoint = 'models/'
-      const { data } = await this._client.get(endpoint)
+      const headers = this._appIdHeader(appId)
+      const endpoint = 'models'
+      const { data } = await this._client.get(endpoint, { headers })
       return data
     })
   }
 
-  public async pruneModels(): Promise<PruneModelsResponseBody | ErrorResponse> {
+  public async pruneModels(appId: string): Promise<PruneModelsResponseBody | ErrorResponse> {
     return this._wrapWithTryCatch(async () => {
+      const headers = this._appIdHeader(appId)
       const endpoint = 'models/prune'
-      const { data } = await this._client.post(endpoint)
+      const { data } = await this._client.post(endpoint, {}, { headers })
       return data
     })
   }
 
   public async detectLanguage(
+    appId: string,
     detectLangRequestBody: DetectLangRequestBody
   ): Promise<DetectLangResponseBody | ErrorResponse> {
     return this._wrapWithTryCatch(async () => {
+      const headers = this._appIdHeader(appId)
       const endpoint = 'detect-lang'
-      const { data } = await this._client.post(endpoint, detectLangRequestBody)
+      const { data } = await this._client.post(endpoint, detectLangRequestBody, { headers })
       return data
     })
   }
 
   public async predict(
+    appId: string,
     modelId: string,
     predictRequestBody: PredictRequestBody
   ): Promise<PredictResponseBody | ErrorResponse> {
     return this._wrapWithTryCatch(async () => {
+      const headers = this._appIdHeader(appId)
       const endpoint = `predict/${modelId}`
-      const { data } = await this._client.post(endpoint, predictRequestBody)
+      const { data } = await this._client.post(endpoint, predictRequestBody, { headers })
       return data
     })
+  }
+
+  private _appIdHeader = (appId: string) => {
+    return {
+      'X-App-Id': appId
+    }
   }
 
   private async _wrapWithTryCatch<T>(fn: () => Promise<T>) {

--- a/packages/nlu-client/src/typings/index.d.ts
+++ b/packages/nlu-client/src/typings/index.d.ts
@@ -14,15 +14,22 @@ import {
 } from './http'
 
 export class Client {
-  constructor(endpoint: string, appId: string, authToken?: string)
+  constructor(endpoint: string)
   getInfo(): Promise<InfoResponseBody | ErrorResponse>
-  startTraining(trainRequestBody: TrainRequestBody): Promise<TrainResponseBody | ErrorResponse>
-  getTrainingStatus(modelId: string): Promise<TrainProgressResponseBody | ErrorResponse>
-  cancelTraining(modelId: string): Promise<SuccessReponse | ErrorResponse>
-  listModels(): Promise<ListModelsResponseBody | ErrorResponse>
-  pruneModels(): Promise<PruneModelsResponseBody | ErrorResponse>
-  detectLanguage(detectLangRequestBody: DetectLangRequestBody): Promise<DetectLangResponseBody | ErrorResponse>
-  predict(modelId: string, predictRequestBody: PredictRequestBody): Promise<PredictResponseBody | ErrorResponse>
+  startTraining(appId: string, trainRequestBody: TrainRequestBody): Promise<TrainResponseBody | ErrorResponse>
+  getTrainingStatus(appId: string, modelId: string): Promise<TrainProgressResponseBody | ErrorResponse>
+  cancelTraining(appId: string, modelId: string): Promise<SuccessReponse | ErrorResponse>
+  listModels(appId: string): Promise<ListModelsResponseBody | ErrorResponse>
+  pruneModels(appId: string): Promise<PruneModelsResponseBody | ErrorResponse>
+  detectLanguage(
+    appId: string,
+    detectLangRequestBody: DetectLangRequestBody
+  ): Promise<DetectLangResponseBody | ErrorResponse>
+  predict(
+    appId: string,
+    modelId: string,
+    predictRequestBody: PredictRequestBody
+  ): Promise<PredictResponseBody | ErrorResponse>
 }
 
 export * as http from './http'


### PR DESCRIPTION
Title pretty much what this PR is about.

This was implemented by asking for appId as method parameter instead of ctor. It is thus only required when truly needed.