### PR TITLE
fix(nlu-engine): training reports progress at least every 10 seconds

### DIFF
--- a/packages/nlu-engine/src/engine/index.ts
+++ b/packages/nlu-engine/src/engine/index.ts
@@ -2,6 +2,7 @@ import Bluebird from 'bluebird'
 import bytes from 'bytes'
 import _ from 'lodash'
 import LRUCache from 'lru-cache'
+import ms from 'ms'
 import sizeof from 'object-sizeof'
 import { PredictOutput, TrainInput } from 'src/typings'
 
@@ -40,7 +41,8 @@ const DEFAULT_ENGINE_OPTIONS: EngineOptions = {
 
 const DEFAULT_TRAINING_OPTIONS: TrainingOptions = {
   progressCallback: () => {},
-  previousModel: undefined
+  previousModel: undefined,
+  minProgressHeartbeat: ms('10s')
 }
 
 interface EngineOptions {
@@ -125,7 +127,7 @@ export default class Engine implements IEngine {
 
     const options = { ...DEFAULT_TRAINING_OPTIONS, ...opt }
 
-    const { previousModel: previousModelId, progressCallback } = options
+    const { previousModel: previousModelId, progressCallback, minProgressHeartbeat } = options
     const previousModel = previousModelId && this.modelsById.get(modelIdService.toString(previousModelId))
 
     const list_entities = entities.filter(isListEntity).map((e) => {
@@ -186,7 +188,8 @@ export default class Engine implements IEngine {
       pattern_entities,
       contexts,
       intents: pipelineIntents,
-      ctxToTrain
+      ctxToTrain,
+      minProgressHeartbeat
     }
 
     const startedAt = new Date()

--- a/packages/nlu-engine/src/typings.d.ts
+++ b/packages/nlu-engine/src/typings.d.ts
@@ -54,6 +54,7 @@ export interface ModelIdArgs extends TrainInput {
 export interface TrainingOptions {
   progressCallback: (x: number) => void
   previousModel: ModelId | undefined
+  minProgressHeartbeat: number
 }
 
 export interface Engine {

--- a/packages/nlu-engine/src/utils/watch-dog.ts
+++ b/packages/nlu-engine/src/utils/watch-dog.ts
@@ -1,0 +1,51 @@
+class Interval<X extends any[]> {
+  private _int: number | undefined
+
+  constructor(private f: Func<X, void>, private ms: number) {
+    this.reset()
+  }
+
+  reset(): void {
+    this.stop()
+    this._int = setInterval(this.f, this.ms)
+  }
+
+  stop(): void {
+    this._int && clearInterval(this._int)
+  }
+}
+
+type Func<X extends any[], Y extends any> = (...x: X) => Y
+
+export interface WatchDog<X extends any[]> {
+  run(...x: X): void
+  stop: () => void
+}
+
+/**
+ *
+ * Basically the opposite of a throttle.
+ * Ensures a function is executed at least every x ms.
+ * Running the function mannualy only resets the timmer.
+ *
+ * @param f Function to run
+ * @param ms Max allowed time beetween function invocation
+ * @returns a watchdog object that can be ran or stopped
+ */
+export const watchDog = <X extends any[]>(f: Func<X, void>, ms: number): WatchDog<X> => {
+  const interval = new Interval(f, ms)
+
+  const run: Func<X, void> = (...x: X): void => {
+    interval.reset()
+    return f(...x)
+  }
+
+  const stop = () => {
+    interval.stop()
+  }
+
+  return {
+    run,
+    stop
+  }
+}


### PR DESCRIPTION
The only way we know if a training is dead or alive is by checking the last time a progress call was made.

This is problematic, because:
- if hard limit is too long, zombies will not be detected for few minutes
- if hard limit is too short, many trainings will incorrectly be considered as zombies because they simply don't report progress often enough.

My solution is to use a watchdog:

A watchdog is the opposite of a throttle. It ensures a function is at least called every X ms. The X value is chosen by the training queue which is also responsible to decide when a training becomes a zombie.