### PR TITLE
svm training improvement 4

### DIFF
--- a/packages/nlu-engine/src/ml/svm/libsvm/grid-search/index.ts
+++ b/packages/nlu-engine/src/ml/svm/libsvm/grid-search/index.ts
@@ -72,7 +72,7 @@ export default (logger?: Logger) => async (
   const total = combs.length * subsets.length
   let done = 0
 
-  const results = await Bluebird.mapSeries(combs, async (comb) => {
+  const results = await Bluebird.map(combs, async (comb) => {
     const params = defaultParameters({
       ...config,
       C: comb[0],
@@ -83,7 +83,7 @@ export default (logger?: Logger) => async (
       coef0: comb[5]
     })
 
-    const nestedPredictions = await Bluebird.mapSeries(subsets, async (ss) => {
+    const nestedPredictions = await Bluebird.map(subsets, async (ss) => {
       const clf = new BaseSVM()
 
       await clf.train(ss.train, seed, params)


### PR DESCRIPTION
# About

This PR is part of a sequence of PR's with name `svm training improvement $n` that presents few improvements or combination of improvements as attempts to make training faster and consume less memory.

⚠️⚠️ Do not merge this PR as we first need to compare with other attempts first. ⚠️⚠️

# Description

This PR basically removes #88 with commit:

fix(nlu-engine): launch svm trainings one after the other (cec8a7a7b8f28bb567d80050e4f3b3e529d0f558)

There's no real need to run grid-search in serial as the ammount of folds is highly reduced by #91.

# Performance

On clinc150 using local lang server with dimension 100:

| branch | memory used (mb) | time to train (s) |
|--------|------------------|-------------------|
| master   | ~800             | 101               |
| this   | ~700           | 82 |


On John Doe* using remote lang server `https://lang-01.botpress.io`

| branch | memory used (gb) | time to train (min) |
|--------|------------------|---------------------|
| master   | ~40              | 20                  |
| this   | ~1.8 | 5 |

* John Doe is an internally-known really big bot