### PR TITLE
feat(nlu-server): add a route to list all trainings of an app

### DIFF
--- a/packages/nlu-client/src/client.ts
+++ b/packages/nlu-client/src/client.ts
@@ -125,7 +125,7 @@ export class NLUClient implements IClient {
       const ret = await fn()
       return ret
     } catch (err) {
-      const { response } = err ?? {}
+      const { response } = (err as any) ?? {}
       if (_.isBoolean(response?.data?.success)) {
         return response.data // in this case the response body contains details about error
       }

--- a/packages/nlu-client/src/client.ts
+++ b/packages/nlu-client/src/client.ts
@@ -14,7 +14,8 @@ import {
   PruneModelsResponseBody,
   PredictRequestBody,
   PredictResponseBody,
-  ErrorResponse
+  ErrorResponse,
+  ListTrainingsResponseBody
 } from './typings/http'
 
 export class NLUClient implements IClient {
@@ -38,6 +39,16 @@ export class NLUClient implements IClient {
     return this._wrapWithTryCatch(async () => {
       const headers = this._appIdHeader(appId)
       const { data } = await this._client.post('train', trainRequestBody, { headers })
+      return data
+    })
+  }
+
+  public async listTrainings(appId: string, lang?: string): Promise<ListTrainingsResponseBody | ErrorResponse> {
+    return this._wrapWithTryCatch(async () => {
+      const headers = this._appIdHeader(appId)
+      const endpoint = 'train'
+      const params = lang && { lang }
+      const { data } = await this._client.get(endpoint, { headers, params })
       return data
     })
   }

--- a/packages/nlu-client/src/typings/http.d.ts
+++ b/packages/nlu-client/src/typings/http.d.ts
@@ -11,7 +11,8 @@ import {
   EntityDefinition,
   Specifications,
   Health,
-  ServerInfo
+  ServerInfo,
+  Training
 } from './sdk'
 
 export interface TrainRequestBody {
@@ -49,6 +50,10 @@ export interface TrainResponseBody extends SuccessReponse {
 
 export interface TrainProgressResponseBody extends SuccessReponse {
   session: TrainingState
+}
+
+export interface ListTrainingsResponseBody extends SuccessReponse {
+  trainings: Training[]
 }
 
 export interface ListModelsResponseBody extends SuccessReponse {

--- a/packages/nlu-client/src/typings/index.d.ts
+++ b/packages/nlu-client/src/typings/index.d.ts
@@ -10,7 +10,8 @@ import {
   ListModelsResponseBody,
   PruneModelsResponseBody,
   PredictResponseBody,
-  DetectLangResponseBody
+  DetectLangResponseBody,
+  ListTrainingsResponseBody
 } from './http'
 
 export class Client {

--- a/packages/nlu-client/src/typings/index.d.ts
+++ b/packages/nlu-client/src/typings/index.d.ts
@@ -17,6 +17,7 @@ export class Client {
   constructor(endpoint: string)
   getInfo(): Promise<InfoResponseBody | ErrorResponse>
   startTraining(appId: string, trainRequestBody: TrainRequestBody): Promise<TrainResponseBody | ErrorResponse>
+  listTrainings(appId: string, lang?: string): Promise<ListTrainingsResponseBody | ErrorResponse>
   getTrainingStatus(appId: string, modelId: string): Promise<TrainProgressResponseBody | ErrorResponse>
   cancelTraining(appId: string, modelId: string): Promise<SuccessReponse | ErrorResponse>
   listModels(appId: string): Promise<ListModelsResponseBody | ErrorResponse>

--- a/packages/nlu-client/src/typings/sdk.d.ts
+++ b/packages/nlu-client/src/typings/sdk.d.ts
@@ -89,6 +89,10 @@ export interface TrainingState {
   error?: TrainingError
 }
 
+export interface Training extends TrainingState {
+  modelId: string
+}
+
 /**
  * ####################################
  * ############ PREDICTION ############

--- a/packages/nlu-server/examples/api.rest
+++ b/packages/nlu-server/examples/api.rest
@@ -147,6 +147,12 @@ X-App-Id: {{appId}}
   ]
 }
 
+### list trainings
+# @name list-trainings
+GET {{api}}/train
+Content-Type: application/json
+X-App-Id: {{appId}}
+
 ### list models
 # @name list-models
 GET {{api}}/models

--- a/packages/nlu-server/src/api/http.ts
+++ b/packages/nlu-server/src/api/http.ts
@@ -1,7 +1,7 @@
 import { http } from '@botpress/nlu-client'
 import { Request, Response, NextFunction } from 'express'
 import _ from 'lodash'
-import { InvalidRequestFormatError, ResponseError, UnauthorizedError } from './errors'
+import { InvalidRequestFormatError, ResponseError } from './errors'
 
 export const handleError = (err: Error, _req: Request, res: Response, _next: NextFunction) => {
   const httpStatusCode = err instanceof ResponseError ? err.statusCode : 500

--- a/packages/nlu-server/src/api/index.ts
+++ b/packages/nlu-server/src/api/index.ts
@@ -84,7 +84,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
     try {
       return res.redirect('/info')
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 
@@ -94,7 +94,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
       const resp: http.InfoResponseBody = { success: true, info }
       res.send(resp)
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 
@@ -106,7 +106,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
       const resp: http.ListModelsResponseBody = { success: true, models: stringIds }
       res.send(resp)
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 
@@ -118,7 +118,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
       const resp: http.PruneModelsResponseBody = { success: true, models: stringIds }
       return res.send(resp)
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 
@@ -142,7 +142,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
       const resp: http.TrainResponseBody = { success: true, modelId: NLUEngine.modelIdService.toString(modelId) }
       return res.send(resp)
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 
@@ -163,7 +163,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
       const resp: http.ListTrainingsResponseBody = { success: true, trainings: serialized }
       res.send(resp)
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 
@@ -181,7 +181,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
       const resp: http.TrainProgressResponseBody = { success: true, session }
       res.send(resp)
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 
@@ -198,7 +198,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
       const resp: http.SuccessReponse = { success: true }
       return res.send(resp)
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 
@@ -221,7 +221,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
       const resp: http.PredictResponseBody = { success: true, predictions }
       res.send(resp)
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 
@@ -248,7 +248,7 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
       const resp: http.DetectLangResponseBody = { success: true, detectedLanguages }
       res.send(resp)
     } catch (err) {
-      return handleError(err, req, res, next)
+      return handleError(err as Error, req, res, next)
     }
   })
 

--- a/packages/nlu-server/src/api/index.ts
+++ b/packages/nlu-server/src/api/index.ts
@@ -146,6 +146,27 @@ export const createAPI = async (options: APIOptions, app: Application, baseLogge
     }
   })
 
+  router.get('/train', async (req, res, next) => {
+    try {
+      const appId = getAppId(req)
+      const { lang } = req.query
+      if (lang && !_.isString(lang)) {
+        throw new InvalidRequestFormatError(`query parameter lang: "${lang}" has invalid format`)
+      }
+
+      const trainings = await app.getAllTrainings(appId, lang)
+      const serialized = trainings.map(({ modelId, ...state }) => ({
+        modelId: modelIdService.toString(modelId),
+        ...state
+      }))
+
+      const resp: http.ListTrainingsResponseBody = { success: true, trainings: serialized }
+      res.send(resp)
+    } catch (err) {
+      return handleError(err, req, res, next)
+    }
+  })
+
   router.get('/train/:modelId', async (req, res, next) => {
     try {
       const appId = getAppId(req)

--- a/packages/nlu-server/src/application/distributed-training-queue.ts
+++ b/packages/nlu-server/src/application/distributed-training-queue.ts
@@ -1,5 +1,4 @@
 import { Logger } from '@botpress/logger'
-import { http } from '@botpress/nlu-client'
 import { Engine, ModelId } from '@botpress/nlu-engine'
 import { ModelRepository } from '../infrastructure/model-repo'
 import { TrainingRepository } from '../infrastructure/training-repo/typings'

--- a/packages/nlu-server/src/bootstrap/documentation.ts
+++ b/packages/nlu-server/src/bootstrap/documentation.ts
@@ -34,6 +34,14 @@ export const displayDocumentation = (logger: Logger, options: NLUServerOptions) 
 {bold POST ${baseUrl}/train}
 
 {green /**
+  * List all trainings.
+  * @header {bold x-app-id} Application ID to make sure there's no collision between models of different applications.
+  * @query_parameter {bold lang} Language code to filter trainings. {yellow ** Optionnal **}
+  * @returns {bold trainings} List of all trainings for your app id.
+ */}
+{bold GET ${baseUrl}/train}
+
+{green /**
   * Gets a training progress status.
   * @header {bold x-app-id} Application ID to make sure there's no collision between models of different applications.
   * @path_parameter {bold modelId} The model id for which you seek the training progress.

--- a/packages/nlu-server/src/infrastructure/model-repo.ts
+++ b/packages/nlu-server/src/infrastructure/model-repo.ts
@@ -67,7 +67,7 @@ export class ModelRepository {
     }
   }
 
-  public async saveModel(model: NLUEngine.Model, appId: string): Promise<void | void[]> {
+  public async saveModel(appId: string, model: NLUEngine.Model): Promise<void | void[]> {
     const serialized = JSON.stringify(model)
 
     const stringId = modelIdService.toString(model.id)

--- a/packages/nlu-server/src/infrastructure/training-repo/typings.ts
+++ b/packages/nlu-server/src/infrastructure/training-repo/typings.ts
@@ -1,4 +1,4 @@
-import { TrainingState as TrainingStateDto, http, TrainInput } from '@botpress/nlu-client'
+import { TrainingState as TrainingStateDto, TrainInput } from '@botpress/nlu-client'
 import { ModelId } from '@botpress/nlu-engine'
 
 export type TrainingTrx = (repo: WrittableTrainingRepository) => Promise<void>
@@ -7,8 +7,8 @@ export interface ReadonlyTrainingRepository {
   initialize: () => Promise<void>
   teardown: () => Promise<void>
   get: (id: TrainingId) => Promise<Training | undefined>
-  query: (query: Partial<TrainingState>) => Promise<Training[]>
-  queryOlderThan: (query: Partial<TrainingState>, threshold: Date) => Promise<Training[]>
+  query: (query: Partial<Training>) => Promise<Training[]>
+  queryOlderThan: (query: Partial<Training>, threshold: Date) => Promise<Training[]>
   delete: (id: TrainingId) => Promise<void>
 }
 
@@ -20,13 +20,15 @@ export interface TrainingRepository extends ReadonlyTrainingRepository {
   inTransaction: (trx: TrainingTrx, name: string) => Promise<void> // Promise resolves once transaction is over
 }
 
-export type TrainingId = ModelId & { appId: string }
+export interface TrainingId {
+  modelId: ModelId
+  appId: string
+}
+
 export type TrainingState = TrainingStateDto & {
   cluster: string
 }
 
-export interface Training {
-  id: TrainingId
-  state: TrainingState
-  set: TrainInput
+export interface Training extends TrainingId, TrainingState {
+  dataset: TrainInput
 }


### PR DESCRIPTION
This PR adds route `GET <base>/train` or `GET <base>/train?lang=en`.

It returns all trainings of an app.