### PR TITLE
fix: check for APP_DATA_PATH environment variable

### DIFF
--- a/packages/lang-server/src/app-data.ts
+++ b/packages/lang-server/src/app-data.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import path from 'path'
 
 export function getAppDataPath() {
-  const homeDir = process.env.HOME || process.env.APPDATA
+  const homeDir = process.env.APP_DATA_PATH || process.env.HOME || process.env.APPDATA
   if (homeDir) {
     if (process.platform === 'darwin') {
       return path.join(homeDir, 'Library', 'Application Support', 'botpress')

--- a/packages/lang-server/src/download.ts
+++ b/packages/lang-server/src/download.ts
@@ -1,12 +1,12 @@
+import { LoggerLevel, makeLogger } from '@botpress/logger'
 import { LanguageService } from '@botpress/nlu-engine'
-import { Logger, LoggerLevel, makeLogger } from '@botpress/logger'
 import cliProgress from 'cli-progress'
 import fse from 'fs-extra'
 import _ from 'lodash'
 import path from 'path'
 
+import { getAppDataPath } from './app-data'
 import DownloadManager from './service/download-manager'
-import { getAppDataPath } from './utils/app-data'
 
 interface Argv {
   langDir?: string

--- a/packages/lang-server/src/run.ts
+++ b/packages/lang-server/src/run.ts
@@ -5,8 +5,8 @@ import _ from 'lodash'
 import path from 'path'
 
 import API, { APIOptions } from './api'
+import { getAppDataPath } from './app-data'
 import DownloadManager from './service/download-manager'
-import { getAppDataPath } from './utils/app-data'
 
 export interface ArgV {
   port: number

--- a/packages/lang-server/src/service/download-manager.ts
+++ b/packages/lang-server/src/service/download-manager.ts
@@ -4,7 +4,7 @@ import fse from 'fs-extra'
 import ms from 'ms'
 import path from 'path'
 import { URL } from 'url'
-import { getAppDataPath } from '../utils/app-data'
+import { getAppDataPath } from '../app-data'
 import ModelDownload from './model-download'
 
 type ModelType = 'bpe' | 'embeddings'

--- a/packages/nlu-cli/src/app-data.ts
+++ b/packages/nlu-cli/src/app-data.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import path from 'path'
 
 export function getAppDataPath() {
-  const homeDir = process.env.HOME || process.env.APPDATA
+  const homeDir = process.env.APP_DATA_PATH || process.env.HOME || process.env.APPDATA
   if (homeDir) {
     if (process.platform === 'darwin') {
       return path.join(homeDir, 'Library', 'Application Support', 'botpress')

--- a/packages/nlu-server/src/app-data.ts
+++ b/packages/nlu-server/src/app-data.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import path from 'path'
 
 export function getAppDataPath() {
-  const homeDir = process.env.HOME || process.env.APPDATA
+  const homeDir = process.env.APP_DATA_PATH || process.env.HOME || process.env.APPDATA
   if (homeDir) {
     if (process.platform === 'darwin') {
       return path.join(homeDir, 'Library', 'Application Support', 'botpress')


### PR DESCRIPTION
this function was probably copied from the core repository, but the function that calls getAppDataPath doesn`t check for APP_DATA_PATH before as the core code does. Added env variable check in this getAppDataPAth so the log makes sense.