### PR TITLE
chore(dx): log build info on startup in nlu-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Builds ###
 dist
+.buildinfo.json
 
 ### OS ###
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     ],
     "assets": [
       "node_modules/@botpress/node-*/**/*.node",
-      "node_modules/@botpress/*/assets/**"
+      "node_modules/@botpress/*/assets/**",
+      "node_modules/@botpress/*/*.json"
     ]
   },
   "scripts": {
@@ -25,6 +26,7 @@
     "dev": "yarn workspace @botpress/nlu-cli dev",
     "start": "cross-env node ./packages/nlu-cli/dist/index.js",
     "build": "tsc --build",
+    "postbuild": "yarn workspace @botpress/nlu-server postbuild",
     "package": "yarn cmd package",
     "e2e": "yarn workspace e2e start",
     "test": "yarn workspaces run test",

--- a/packages/bitfan/package.json
+++ b/packages/bitfan/package.json
@@ -8,7 +8,7 @@
   "repository": "git://github.com/botpress/nlu.git",
   "types": "./src/bitfan.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "jest"
   },
   "publishConfig": {
@@ -42,6 +42,6 @@
     "babel-jest": "^24.0.0",
     "jest": "^24.0.0",
     "ts-jest": "^24.3.0",
-    "typescript": "~4.0.0"
+    "typescript": "^3.9.10"
   }
 }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -15,8 +15,8 @@
   "devDependencies": {
     "@types/lodash": "^4.14.116",
     "@types/fs-extra": "^5.0.4",
-    "typescript": "^3.9.7",
-    "@types/node": "^12.13.0"
+    "@types/node": "^12.13.0",
+    "typescript": "^3.9.10"
   },
   "scripts": {
     "start": "node ./dist/index.js",

--- a/packages/lang-server/package.json
+++ b/packages/lang-server/package.json
@@ -49,11 +49,11 @@
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.5",
     "ts-node-dev": "^1.1.6",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.10"
   },
   "scripts": {
     "dev": "cross-env ts-node-dev ./src/index.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "start": "cross-env node ./dist/index.js",
     "test": "echo \"no tests\""
   }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,10 +13,11 @@
     "@types/lodash": "^4.14.116",
     "@types/node": "^12.13.0",
     "jest": "^24.9.0",
-    "ts-jest": "^26.5.5"
+    "ts-jest": "^26.5.5",
+    "typescript": "^3.9.10"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "cross-env jest -i --detectOpenHandles -c jest.config.js"
   }
 }

--- a/packages/nlu-cli/package.json
+++ b/packages/nlu-cli/package.json
@@ -33,12 +33,12 @@
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.5",
     "ts-node-dev": "^1.1.6",
-    "typescript": "^3.9.7",
-    "@types/node": "^12.13.0"
+    "@types/node": "^12.13.0",
+    "typescript": "^3.9.10"
   },
   "scripts": {
     "dev": "cross-env ts-node-dev ./src/index.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "start": "cross-env node ./dist/index.js",
     "test": "echo \"no tests\""
   }

--- a/packages/nlu-client/package.json
+++ b/packages/nlu-client/package.json
@@ -5,7 +5,7 @@
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "echo \"no tests\""
   },
   "dependencies": {
@@ -14,7 +14,8 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.116",
-    "@types/node": "^12.13.0"
+    "@types/node": "^12.13.0",
+    "typescript": "^3.9.10"
   },
   "types": "./src/typings/index.d.ts",
   "main": "./dist/index.js"

--- a/packages/nlu-engine/package.json
+++ b/packages/nlu-engine/package.json
@@ -4,7 +4,7 @@
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "cross-env jest -i --detectOpenHandles -c jest.config.js"
   },
   "dependencies": {
@@ -62,7 +62,7 @@
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.5",
     "ts-node-dev": "^1.1.6",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.10"
   },
   "types": "./src/typings.d.ts",
   "main": "./dist/index.js"

--- a/packages/nlu-server/package.json
+++ b/packages/nlu-server/package.json
@@ -76,11 +76,11 @@
     "supertest": "^6.1.3",
     "ts-jest": "^26.5.5",
     "ts-node-dev": "^1.1.6",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.10"
   },
   "scripts": {
     "dev": "cross-env ts-node-dev ./src/index.ts",
-    "build": "tsc",
+    "build": "tsc --build",
     "start": "cross-env node ./dist/index.js",
     "test": "cross-env jest -i --detectOpenHandles -c jest.config.js"
   }

--- a/packages/nlu-server/package.json
+++ b/packages/nlu-server/package.json
@@ -81,6 +81,7 @@
   "scripts": {
     "dev": "cross-env ts-node-dev ./src/index.ts",
     "build": "tsc --build",
+    "postbuild": "cross-env node ./scripts/buildinfo.js ./.buildinfo.json",
     "start": "cross-env node ./dist/index.js",
     "test": "cross-env jest -i --detectOpenHandles -c jest.config.js"
   }

--- a/packages/nlu-server/scripts/buildinfo.js
+++ b/packages/nlu-server/scripts/buildinfo.js
@@ -1,0 +1,26 @@
+const { exec } = require('child_process')
+const fse = require('fs-extra')
+const yargs = require('yargs')
+
+const getCurrentGitBranch = () => {
+  return new Promise((resolve, reject) => {
+    exec('git rev-parse --abbrev-ref HEAD', (err, currentBranch) => {
+      if (err) {
+        return reject(err)
+      }
+      return resolve(currentBranch.replace('\n', ''))
+    })
+  })
+}
+
+yargs
+  .command(['$0 <filePath>'], 'Create Build Info File', {}, async (argv) => {
+    try {
+      const branch = await getCurrentGitBranch()
+      const metadata = { date: Date.now(), branch }
+      await fse.writeJSON(argv.filePath, metadata)
+    } catch (err) {
+      console.error("Couldn't get active branch", err)
+    }
+  })
+  .help().argv

--- a/packages/nlu-server/src/bootstrap/banner.ts
+++ b/packages/nlu-server/src/bootstrap/banner.ts
@@ -1,0 +1,40 @@
+import { centerText, Logger } from '@botpress/logger'
+import chalk from 'chalk'
+
+import _ from 'lodash'
+import moment from 'moment'
+
+interface BuildMetadata {
+  date: number
+  branch: string
+}
+
+interface BannerConfig {
+  title: string
+  version: string
+  buildInfo?: BuildMetadata
+  bannerWidth: number
+  logScopeLength: number
+  logger: Logger
+}
+
+export const showBanner = (config: BannerConfig) => {
+  const { title, version, buildInfo, logScopeLength, bannerWidth, logger } = config
+
+  const versionLine = `Version ${version}`
+
+  let buildLine: string | undefined
+  if (buildInfo) {
+    const builtFrom = process.pkg ? 'BIN' : 'SRC'
+    const branchInfo = buildInfo.branch !== 'master' ? `/${buildInfo.branch}` : ''
+    buildLine = `Build ${moment(buildInfo.date).format('YYYYMMDD-HHmm')}_${builtFrom}${branchInfo}`
+  }
+
+  const infos = [versionLine, buildLine].filter((x) => x !== undefined)
+  const border = _.repeat('=', bannerWidth)
+
+  logger.info(`${border}
+${chalk.bold(centerText(title, bannerWidth, logScopeLength))}
+${chalk.gray(centerText(infos.join(' - '), bannerWidth, logScopeLength))}
+${_.repeat(' ', logScopeLength)}${border}`)
+}

--- a/packages/nlu-server/src/bootstrap/launcher.ts
+++ b/packages/nlu-server/src/bootstrap/launcher.ts
@@ -1,11 +1,14 @@
-import { centerText, Logger } from '@botpress/logger'
+import { Logger } from '@botpress/logger'
 import chalk from 'chalk'
 import _ from 'lodash'
+import { BuildInfo } from '../typings'
+import { showBanner } from './banner'
 import { ConfigSource, NLUServerOptions } from './config'
 import { displayDocumentation } from './documentation'
 
 interface LaunchingInfo {
   version: string
+  buildInfo?: BuildInfo
   configSource: ConfigSource
   configFile?: string
 }
@@ -13,10 +16,14 @@ interface LaunchingInfo {
 export const logLaunchingMessage = (info: NLUServerOptions & LaunchingInfo, launcherLogger: Logger) => {
   launcherLogger.debug('NLU Server Options %o', info)
 
-  launcherLogger.info(chalk`========================================
-      {bold ${centerText('Botpress Standalone NLU', 40, 9)}}
-      {dim ${centerText(`Version ${info.version}`, 40, 9)}}
-${_.repeat(' ', 9)}========================================`)
+  showBanner({
+    title: 'Botpress Standalone NLU',
+    version: info.version,
+    buildInfo: info.buildInfo,
+    logScopeLength: 9,
+    bannerWidth: 75,
+    logger: launcherLogger
+  })
 
   if (info.configSource === 'environment') {
     launcherLogger.info('Loading config from environment variables')

--- a/packages/nlu-server/src/require-json.ts
+++ b/packages/nlu-server/src/require-json.ts
@@ -1,0 +1,6 @@
+export const requireJSON = <T>(filePath: string): T | undefined => {
+  try {
+    const fileContent = require(filePath)
+    return fileContent
+  } catch (err) {}
+}

--- a/packages/nlu-server/src/typings.d.ts
+++ b/packages/nlu-server/src/typings.d.ts
@@ -1,3 +1,8 @@
+interface BuildInfo {
+  date: number
+  branch: string
+}
+
 interface Options {
   host: string
   port: number

--- a/packages/node-crfsuite/package.json
+++ b/packages/node-crfsuite/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "install": ":",
     "build-native": "node-gyp install && node-gyp rebuild",
-    "build": "./node_modules/.bin/tsc",
+    "build": "tsc --build",
     "test": "echo \"no tests\""
   },
   "keywords": [
@@ -38,7 +38,7 @@
   "devDependencies": {
     "node-addon-api": "^3.0.0",
     "node-gyp": "^5.0.0",
-    "typescript": "^3.9.5",
-    "@types/node": "^12.13.0"
+    "@types/node": "^12.13.0",
+    "typescript": "^3.9.10"
   }
 }

--- a/packages/node-fasttext/package.json
+++ b/packages/node-fasttext/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "install": ":",
     "build-native": "node-gyp install && node-gyp rebuild",
-    "build": "./node_modules/.bin/tsc",
+    "build": "tsc --build",
     "test": "echo \"no tests\""
   },
   "repository": {
@@ -31,7 +31,7 @@
     "@types/node": "^12.13.0",
     "node-addon-api": "^3.0.0",
     "node-gyp": "^7.0.0",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.10"
   },
   "files": [
     "src",

--- a/packages/node-sentencepiece/package.json
+++ b/packages/node-sentencepiece/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "gypfile": true,
   "scripts": {
-    "build": "./node_modules/.bin/tsc",
+    "build": "tsc --build",
     "install": ":",
     "clean": "node-gyp clean",
     "build-native": "run-script-os",
@@ -21,7 +21,7 @@
     "node-gyp": "^4.0.0",
     "node-addon-api": "^1.6.3",
     "run-script-os": "^1.0.5",
-    "typescript": "^3.9.7",
-    "@types/node": "^12.13.0"
+    "@types/node": "^12.13.0",
+    "typescript": "^3.9.10"
   }
 }

--- a/packages/node-svm/package.json
+++ b/packages/node-svm/package.json
@@ -15,7 +15,7 @@
     "install": ":",
     "build-native": "node-gyp install && node-gyp rebuild",
     "clean": "node-gyp clean",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "jest -i --detectOpenHandles -c ./jest.config.js"
   },
   "gypfile": true,
@@ -25,9 +25,9 @@
     "@types/getos": "^3.0.0",
     "node-addon-api": "^2.0.0",
     "node-gyp": "^6.1.0",
-    "typescript": "^3.9.5",
     "jest": "^24.9.0",
     "ts-jest": "^26.5.5",
-    "@types/node": "^12.13.0"
+    "@types/node": "^12.13.0",
+    "typescript": "^3.9.10"
   }
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -4,7 +4,7 @@
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "echo \"no tests\""
   },
   "dependencies": {
@@ -14,7 +14,8 @@
   "devDependencies": {
     "@types/lodash": "^4.14.116",
     "@types/yn": "^3.1.0",
-    "@types/node": "^12.13.0"
+    "@types/node": "^12.13.0",
+    "typescript": "^3.9.10"
   },
   "types": "./src/typings.d.ts",
   "main": "./dist/index.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9312,15 +9312,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.5, typescript@^3.9.7:
-  version "3.9.9"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
-  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
-
-typescript@~4.0.0:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.7.tgz#7168032c43d2a2671c95c07812f69523c79590af"
-  integrity sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==
+typescript@^3.9.10:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 uglify-js@^3.1.4:
   version "3.13.8"


### PR DESCRIPTION
This PR contains 2 commits:

1. (8413fbba2fb38c64b5948ee5ae010b1dd6bd20a6) Simply standardize the version of typescript used by all sub packages
2. (7fb5b1b78d07e6ad4395bf5013416d82ca7b1058) Display build information and metadata when booting nlu-server 

For the second one, here's how this works:

1. in a `"postbuild"` script, I generate a `.buildinfo.json` file at the root of nlu-server.
2. when booting nlu-server I try reading this file and if it's present I display its content
3. when packaging in binaries, I make sure `*.json` file at the root of sub packages are included in binary.

Result looks like this:
![image](https://user-images.githubusercontent.com/25970722/133144043-d385c3e2-3957-433c-b4f5-1adc79675c9f.png)
