### PR TITLE
feat(nlu-client): make nlu-client configurable with an axios config

### DIFF
--- a/packages/bitfan/src/services/bp-provider/stan-provider.ts
+++ b/packages/bitfan/src/services/bp-provider/stan-provider.ts
@@ -11,7 +11,7 @@ export class StanProvider {
   private _client: Client
 
   constructor(nluServerEndpoint: string = 'http://localhost:3200') {
-    this._client = new Client(nluServerEndpoint)
+    this._client = new Client({ baseURL: nluServerEndpoint })
   }
 
   private async _getTrainingStatus(modelId: string): Promise<TrainingState> {

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -9,7 +9,6 @@
     "outDir": "./dist" /* Redirect output structure to the directory. */,
     "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-    "types": ["node"],
     "baseUrl": ".",
     "composite": true,
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]

--- a/packages/locks/tsconfig.json
+++ b/packages/locks/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "./dist" /* Redirect output structure to the directory. */,
     "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-    "types": ["node"],
     "baseUrl": ".",
     "composite": true,
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]

--- a/packages/nlu-client/jest.config.js
+++ b/packages/nlu-client/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['dist', 'node_modules'],
+  rootDir: '.',
+  resetModules: true,
+  verbose: true,
+  modulePaths: ['<rootDir>/src/'],
+  moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'd.ts'],
+  modulePathIgnorePatterns: ['out']
+}

--- a/packages/nlu-client/package.json
+++ b/packages/nlu-client/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.116",
-    "@types/joi": "^17.4.2",
+    "@types/joi": "^17.2.3",
     "@types/node": "^12.13.0",
     "@types/jest": "^24.9.0",
     "jest": "^24.9.0",

--- a/packages/nlu-client/package.json
+++ b/packages/nlu-client/package.json
@@ -6,15 +6,20 @@
   "license": "AGPL-3.0",
   "scripts": {
     "build": "tsc --build",
-    "test": "echo \"no tests\""
+    "test": "jest"
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
+    "joi": "^17.2.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.116",
+    "@types/joi": "^17.4.2",
     "@types/node": "^12.13.0",
+    "@types/jest": "^24.9.0",
+    "jest": "^24.9.0",
+    "ts-jest": "^26.5.5",
     "typescript": "^3.9.10"
   },
   "types": "./src/typings/index.d.ts",

--- a/packages/nlu-client/src/typings/index.d.ts
+++ b/packages/nlu-client/src/typings/index.d.ts
@@ -13,9 +13,13 @@ import {
   DetectLangResponseBody,
   ListTrainingsResponseBody
 } from './http'
+import { AxiosRequestConfig, AxiosInstance } from 'axios'
 
 export class Client {
-  constructor(endpoint: string)
+  readonly axios: AxiosInstance
+
+  constructor(config: AxiosRequestConfig)
+
   getInfo(): Promise<InfoResponseBody | ErrorResponse>
   startTraining(appId: string, trainRequestBody: TrainRequestBody): Promise<TrainResponseBody | ErrorResponse>
   listTrainings(appId: string, lang?: string): Promise<ListTrainingsResponseBody | ErrorResponse>

--- a/packages/nlu-client/src/validation.test.ts
+++ b/packages/nlu-client/src/validation.test.ts
@@ -1,0 +1,56 @@
+import { validateResponse } from './validation'
+import { SuccessReponse, ErrorResponse } from './typings/http'
+
+test('validating with absent success key should fail', async () => {
+  // arrange && act && assert
+  expect(() => validateResponse({})).toThrow()
+  expect(() => validateResponse({ someKey: 'some text' })).toThrow()
+})
+
+test('validating a successfull response should pass', async () => {
+  // arrange
+  const res: SuccessReponse = { success: true }
+
+  // act && assert
+  expect(() => validateResponse(res)).not.toThrow()
+})
+
+test('validating an unsuccessfull response with unempty error should pass', async () => {
+  // arrange
+  const res: ErrorResponse = { success: false, error: 'an error' }
+
+  // act && assert
+  expect(() => validateResponse(res)).not.toThrow()
+})
+
+test('validating an unsuccessfull response with empty error should still pass', async () => {
+  // arrange
+  const res: ErrorResponse = { success: false, error: '' }
+
+  // act && assert
+  expect(() => validateResponse(res)).not.toThrow()
+})
+
+test('validating an unsuccessfull response with undefined error should fail', async () => {
+  // arrange
+  const res: Partial<ErrorResponse> = { success: false }
+
+  // act && assert
+  expect(() => validateResponse(res)).toThrow()
+})
+
+test('validating a successfull response with unknown keys should pass', async () => {
+  // arrange
+  const res = <SuccessReponse>{ success: true, someExtraKey: 'hellooooo' }
+
+  // act && assert
+  expect(() => validateResponse(res)).not.toThrow()
+})
+
+test('validating an unsuccessfull response with unknown keys should pass', async () => {
+  // arrange
+  const res = <ErrorResponse>{ success: false, error: 'some error', someExtraKey: 'lololol' }
+
+  // act && assert
+  expect(() => validateResponse(res)).not.toThrow()
+})

--- a/packages/nlu-client/src/validation.test.ts
+++ b/packages/nlu-client/src/validation.test.ts
@@ -1,6 +1,18 @@
 import { validateResponse } from './validation'
 import { SuccessReponse, ErrorResponse } from './typings/http'
 
+const augmentWithExtraKey = (res: Object) => {
+  return [
+    { ...res, someExtraKey: undefined },
+    { ...res, someExtraKey: null },
+    { ...res, someExtraKey: '' },
+    { ...res, someExtraKey: 'a value' },
+    { ...res, someExtraKey: 69 },
+    { ...res, someExtraKey: { key1: 69, key2: '42' } },
+    { ...res, someExtraKey: [{ key1: 69, key2: '42' }, 666] }
+  ]
+}
+
 test('validating with absent success key should fail', async () => {
   // arrange && act && assert
   expect(() => validateResponse({})).toThrow()
@@ -41,16 +53,22 @@ test('validating an unsuccessfull response with undefined error should fail', as
 
 test('validating a successfull response with unknown keys should pass', async () => {
   // arrange
-  const res = <SuccessReponse>{ success: true, someExtraKey: 'hellooooo' }
+  const res = <SuccessReponse>{ success: true }
 
   // act && assert
-  expect(() => validateResponse(res)).not.toThrow()
+  const responses = augmentWithExtraKey(res)
+  responses.forEach((r) => {
+    expect(() => validateResponse(r)).not.toThrow()
+  })
 })
 
 test('validating an unsuccessfull response with unknown keys should pass', async () => {
   // arrange
-  const res = <ErrorResponse>{ success: false, error: 'some error', someExtraKey: 'lololol' }
+  const res = <ErrorResponse>{ success: false, error: 'some error' }
 
   // act && assert
-  expect(() => validateResponse(res)).not.toThrow()
+  const responses = augmentWithExtraKey(res)
+  responses.forEach((r) => {
+    expect(() => validateResponse(r)).not.toThrow()
+  })
 })

--- a/packages/nlu-client/src/validation.ts
+++ b/packages/nlu-client/src/validation.ts
@@ -1,0 +1,38 @@
+import Joi from 'joi'
+import { SuccessReponse, ErrorResponse } from './typings/http'
+
+const allowUnknownKeys = (obj: Joi.ObjectSchema): Joi.ObjectSchema => {
+  return obj.pattern(/./, Joi.string())
+}
+
+const ERROR_RESPONSE_SCHEMA = allowUnknownKeys(
+  Joi.object().keys({
+    success: Joi.boolean().strict().not(true).required(),
+    error: Joi.string().allow('').required()
+  })
+)
+
+const SUCCESS_RESPONSE_SCHEMA = allowUnknownKeys(
+  Joi.object().keys({
+    success: Joi.boolean().strict().not(false).required()
+  })
+)
+
+const RESPONSE_SCHEMA = Joi.object()
+  .keys({ success: Joi.boolean().required() })
+  .when('.success', {
+    switch: [
+      {
+        is: true,
+        then: SUCCESS_RESPONSE_SCHEMA
+      },
+      {
+        is: false,
+        then: ERROR_RESPONSE_SCHEMA
+      }
+    ]
+  })
+
+export const validateResponse = <S extends SuccessReponse>(res: any): S | ErrorResponse => {
+  return Joi.attempt(res, RESPONSE_SCHEMA)
+}

--- a/packages/nlu-client/src/validation.ts
+++ b/packages/nlu-client/src/validation.ts
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { SuccessReponse, ErrorResponse } from './typings/http'
 
 const allowUnknownKeys = (obj: Joi.ObjectSchema): Joi.ObjectSchema => {
-  return obj.pattern(/./, Joi.string())
+  return obj.pattern(/./, Joi.any())
 }
 
 const ERROR_RESPONSE_SCHEMA = allowUnknownKeys(

--- a/packages/nlu-client/tsconfig.json
+++ b/packages/nlu-client/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "./dist" /* Redirect output structure to the directory. */,
     "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-    "types": ["node"],
     "baseUrl": ".",
     "composite": true,
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]

--- a/packages/nlu-server/package.json
+++ b/packages/nlu-server/package.json
@@ -76,9 +76,9 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^32.3.2",
-    "jest": "^24.9.0",
     "prettier": "^2.2.1",
     "supertest": "^6.1.3",
+    "jest": "^24.9.0",
     "ts-jest": "^26.5.5",
     "ts-node-dev": "^1.1.6",
     "typescript": "^3.9.10"

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "./dist" /* Redirect output structure to the directory. */,
     "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-    "types": ["node"],
     "baseUrl": ".",
     "composite": true,
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5764,7 +5764,7 @@ jest@^24.0.0, jest@^24.9.0:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
-joi@*, joi@^17.4.2:
+joi@*, joi@^17.2.2:
   version "17.4.2"
   resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.2.tgz#02f4eb5cf88e515e614830239379dcbbe28ce7f7"
   integrity sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,6 +920,18 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@hapi/hoek@^9.0.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
+  integrity sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==
+
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -1240,6 +1252,23 @@
     "@sentry/types" "6.9.0"
     tslib "^1.9.3"
 
+"@sideway/address@^4.1.0":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
+  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
+
 "@types/babel__core@^7.1.0":
   version "7.1.14"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"
@@ -1432,6 +1461,13 @@
   version "13.6.3"
   resolved "https://registry.yarnpkg.com/@types/joi/-/joi-13.6.3.tgz#79364839a9cc2c6d4d915ef8822e1f703e28648f"
   integrity sha512-n5tDa0/3MUtHsA2fVH+emDfGQkPramIpWaOvWS+7C/Yq7bn2j979RAIy9pbl4F4hSE5lwjgBXhJN019DP+3ofg==
+
+"@types/joi@^17.4.2":
+  version "17.2.3"
+  resolved "https://registry.yarnpkg.com/@types/joi/-/joi-17.2.3.tgz#b7768ed9d84f1ebd393328b9f97c1cf3d2b94798"
+  integrity sha512-dGjs/lhrWOa+eO0HwgxCSnDm5eMGCsXuvLglMghJq32F6q5LyyNuXb41DHzrg501CKNOSSAHmfB7FDGeUnDmzw==
+  dependencies:
+    joi "*"
 
 "@types/json-schema@^7.0.3":
   version "7.0.7"
@@ -5727,6 +5763,17 @@ jest@^24.0.0, jest@^24.9.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
+
+joi@*, joi@^17.4.2:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.2.tgz#02f4eb5cf88e515e614830239379dcbbe28ce7f7"
+  integrity sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 joi@^13.6.0:
   version "13.7.0"


### PR DESCRIPTION
This PR allows:

1. to pass an axios config at the nlu-client ctor
2. to access the axios instance of the nlu-client (in read only)
3. won't throw on error status code that are expected and part of a normal nlu-server life-cycle (ex: 404 if no model)