### PR TITLE
feat(nlu-server): nlu-server won't serve models of invalid spec

### DIFF
--- a/packages/nlu-server/src/application/errors.ts
+++ b/packages/nlu-server/src/application/errors.ts
@@ -15,6 +15,12 @@ export class TrainingNotFoundError extends ResponseError {
   }
 }
 
+export class InvalidModelSpecError extends ResponseError {
+  constructor(modelId: ModelId, currentSpec: string) {
+    super(`expected spec hash to be "${currentSpec}". target model has spec "${modelId.specificationHash}".`, 400)
+  }
+}
+
 export class TrainingAlreadyStartedError extends ResponseError {
   constructor(appId: string, modelId: ModelId) {
     const stringId = modelIdService.toString(modelId)

--- a/packages/nlu-server/src/application/index.ts
+++ b/packages/nlu-server/src/application/index.ts
@@ -86,7 +86,7 @@ export class Application {
     const hasACorrespondingTraining = (m: ModelId) => sessions.some(({ modelId }) => modelIdService.areSame(modelId, m))
 
     const filters = { ...this._getSpecFilter(), languageCode }
-    const models = await this._modelRepo.listModels(appId, filters)
+    const models = await this._modelRepo.listModels(appId, _.pickBy(filters, _.negate(_.isUndefined)))
     const doneSessions = models
       .filter(_.negate(hasACorrespondingTraining))
       .map((modelId) => ({ modelId, status: <TrainingStatus>'done', progress: 1 }))


### PR DESCRIPTION
**WIP**

calling 
- `GET /models`
- `GET /train`

won't return models of invalid specs

calling
- `GET /train/:modelId`
- `GET /predict/:modelId`
- `GET /detect-lang`

with models of invalid spec will return HTTP 400 with message:

`"expected spec hash to be "010effb865ff25fa". target model has spec "4d8dcf8e284f431a"`
