### PR TITLE
chore(lang-server): pass language as a path param for all routes

### DIFF
--- a/packages/lang-client/package.json
+++ b/packages/lang-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/lang-client",
-  "version": "0.0.1",
+  "version": "1.2.0",
   "description": "Client and typings for Language Server's API",
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",

--- a/packages/lang-client/src/client.ts
+++ b/packages/lang-client/src/client.ts
@@ -39,17 +39,17 @@ export class LangClient implements IClient {
     return validateResponse<InfoResponseBody>(call, res)
   }
 
-  public async tokenize(utterances: string[], language: string): Promise<TokenizeResponseBody | ErrorResponse> {
-    const ressource = 'tokenize'
-    const body: TokenizeRequestBody = { utterances, language }
+  public async tokenize(utterances: string[], lang: string): Promise<TokenizeResponseBody | ErrorResponse> {
+    const ressource = `tokenize/${lang}`
+    const body: TokenizeRequestBody = { utterances }
     const call: HTTPCall<'POST'> = { verb: 'POST', ressource }
     const res = await this._post(call, body)
     return validateResponse<TokenizeResponseBody>(call, res)
   }
 
-  public async vectorize(tokens: string[], language: string): Promise<VectorizeResponseBody | ErrorResponse> {
-    const ressource = 'vectorize'
-    const body: VectorizeRequestBody = { tokens, language }
+  public async vectorize(tokens: string[], lang: string): Promise<VectorizeResponseBody | ErrorResponse> {
+    const ressource = `vectorize/${lang}`
+    const body: VectorizeRequestBody = { tokens }
     const call: HTTPCall<'POST'> = { verb: 'POST', ressource }
     const res = await this._post(call, body)
     return validateResponse<VectorizeResponseBody>(call, res)

--- a/packages/lang-client/src/typings.d.ts
+++ b/packages/lang-client/src/typings.d.ts
@@ -93,12 +93,10 @@ export interface DownloadLangResponseBody extends SuccessReponse, DownloadStartR
 
 export interface TokenizeRequestBody {
   utterances: string[]
-  language: string
 }
 
 export interface VectorizeRequestBody {
   tokens: string[]
-  language: string
 }
 
 /**

--- a/packages/lang-server/src/api/index.ts
+++ b/packages/lang-server/src/api/index.ts
@@ -85,7 +85,6 @@ export default async function (options: APIOptions, baseLogger: Logger, applicat
   const waitForServiceMw = serviceLoadingMiddleware(application.languageService)
   const validateLanguageMw = extractPathLanguageMiddleware(application.languageService)
   const adminTokenMw = authMiddleware(options.adminToken, baseLogger)
-
   const handleErr = handleUnexpectedError(logger)
 
   app.get('/info', (req, res, next) => {
@@ -97,7 +96,7 @@ export default async function (options: APIOptions, baseLogger: Logger, applicat
       }
       return res.json(response)
     } catch (err) {
-      return handleErr(err, req, res, next)
+      return next(err)
     }
   })
 
@@ -112,7 +111,7 @@ export default async function (options: APIOptions, baseLogger: Logger, applicat
       }
       return res.set(cachePolicy).json(response)
     } catch (err) {
-      return handleErr(err, req, res, next)
+      return next(err)
     }
   })
 
@@ -127,7 +126,7 @@ export default async function (options: APIOptions, baseLogger: Logger, applicat
       }
       return res.set(cachePolicy).json(response)
     } catch (err) {
-      return handleErr(err, req, res, next)
+      return next(err)
     }
   })
 
@@ -142,7 +141,7 @@ export default async function (options: APIOptions, baseLogger: Logger, applicat
       }
       return res.json(response)
     } catch (err) {
-      return handleErr(err, req, res, next)
+      return next(err)
     }
   })
 
@@ -153,7 +152,7 @@ export default async function (options: APIOptions, baseLogger: Logger, applicat
       const response: DownloadLangResponseBody = { success: true, downloadId }
       return res.json(response)
     } catch (err) {
-      return handleErr(err, req, res, next)
+      return next(err)
     }
   })
 
@@ -164,7 +163,7 @@ export default async function (options: APIOptions, baseLogger: Logger, applicat
       const response: SuccessReponse = { success: true }
       return res.json(response)
     } catch (err) {
-      return handleErr(err, req, res, next)
+      return next(err)
     }
   })
 
@@ -175,7 +174,7 @@ export default async function (options: APIOptions, baseLogger: Logger, applicat
       const response: SuccessReponse = { success: true }
       return res.json(response)
     } catch (err) {
-      return handleErr(err, req, res, next)
+      return next(err)
     }
   })
 
@@ -186,11 +185,12 @@ export default async function (options: APIOptions, baseLogger: Logger, applicat
       const response: SuccessReponse = { success: true }
       return res.json(response)
     } catch (err) {
-      return handleErr(err, req, res, next)
+      return next(err)
     }
   })
 
   app.use('/languages', waitForServiceMw, router)
+  app.use(handleErr)
 
   const httpServer = createServer(app)
 

--- a/packages/lang-server/src/api/validation/body.ts
+++ b/packages/lang-server/src/api/validation/body.ts
@@ -1,36 +1,24 @@
 import { TokenizeRequestBody, VectorizeRequestBody } from '@botpress/lang-client'
-import { LanguageService } from '@botpress/nlu-engine'
 import _ from 'lodash'
 import { BadRequestError } from '../errors'
-import { validateLanguage } from './lang-path'
 
-export const validateTokenizeRequestBody = (service: LanguageService) => {
-  const languageValidator = validateLanguage(service)
+export const validateTokenizeRequestBody = (body: any): TokenizeRequestBody => {
+  const { utterances } = body
+  if (!utterances || !utterances.length || !_.isArray(utterances) || utterances.some((u) => !_.isString(u))) {
+    throw new BadRequestError('Param "utterances" is mandatory (must be an array of strings)')
+  }
 
-  return (body: any): TokenizeRequestBody => {
-    const { utterances, language } = body
-    if (!utterances || !utterances.length || !_.isArray(utterances) || utterances.some((u) => !_.isString(u))) {
-      throw new BadRequestError('Param "utterances" is mandatory (must be an array of strings)')
-    }
-
-    return {
-      utterances,
-      language: languageValidator(language)
-    }
+  return {
+    utterances
   }
 }
 
-export const validateVectorizeRequestBody = (service: LanguageService) => {
-  const languageValidator = validateLanguage(service)
-
-  return (body: any): VectorizeRequestBody => {
-    const { tokens, language } = body
-    if (!tokens || !tokens.length || !_.isArray(tokens) || tokens.some((t) => !_.isString(t))) {
-      throw new BadRequestError('Param "tokens" is mandatory (must be an array of strings)')
-    }
-    return {
-      tokens,
-      language: languageValidator(language)
-    }
+export const validateVectorizeRequestBody = (body: any): VectorizeRequestBody => {
+  const { tokens } = body
+  if (!tokens || !tokens.length || !_.isArray(tokens) || tokens.some((t) => !_.isString(t))) {
+    throw new BadRequestError('Param "tokens" is mandatory (must be an array of strings)')
+  }
+  return {
+    tokens
   }
 }

--- a/packages/lang-server/src/api/validation/lang-path.ts
+++ b/packages/lang-server/src/api/validation/lang-path.ts
@@ -4,10 +4,10 @@ import _ from 'lodash'
 import { BadRequestError } from './../errors'
 
 export type RequestWithLang = Request & {
-  language?: string
+  params: { lang: string }
 }
 
-export const validateLanguage = (service: LanguageService) => (language: any): string => {
+export const assertLanguage = (service: LanguageService, language: any): void => {
   if (!language) {
     throw new BadRequestError("Param 'lang' is mandatory")
   }
@@ -21,16 +21,13 @@ export const validateLanguage = (service: LanguageService) => (language: any): s
     throw new BadRequestError(`Param 'lang': ${language} is not element of the available languages`)
   }
 
-  return language
+  // language is valid
 }
 
 export const extractPathLanguageMiddleware = (service: LanguageService) => {
-  const languageValidator = validateLanguage(service)
-
   return (req: Request, _res: Response, next: NextFunction) => {
     try {
-      const language = languageValidator(req.params.lang)
-      ;(req as RequestWithLang).language = language
+      assertLanguage(service, req.params.lang)
       next()
     } catch (err) {
       next(err)

--- a/packages/lang-server/src/api/validation/lang-path.ts
+++ b/packages/lang-server/src/api/validation/lang-path.ts
@@ -1,6 +1,7 @@
 import { LanguageService } from '@botpress/nlu-engine'
 import { NextFunction, Request, Response } from 'express'
 import _ from 'lodash'
+import { LANGUAGES } from '../../languages'
 import { BadRequestError } from './../errors'
 
 export type RequestWithLang = Request & {
@@ -14,6 +15,10 @@ export const assertLanguage = (service: LanguageService, language: any): void =>
 
   if (!_.isString(language)) {
     throw new BadRequestError(`Param 'lang': ${language} must be a string`)
+  }
+
+  if (!_(LANGUAGES).keys().includes(language)) {
+    throw new BadRequestError(`Param 'lang': ${language} is not an iso 639-1 language code`)
   }
 
   const availableLanguages = service.getModels().map((x) => x.lang)


### PR DESCRIPTION
The `cloud` branch has already made slight changes to the language server's API, I figured: while we're at it, why not break it even more.