### PR TITLE
fix(cli): fix max training parameter to allow the value 0

### DIFF
--- a/packages/nlu-server/src/application/training-queue.ts
+++ b/packages/nlu-server/src/application/training-queue.ts
@@ -44,7 +44,7 @@ export default class TrainingQueue {
     opt: Partial<QueueOptions> = {}
   ) {
     this.logger = logger.sub('training-queue')
-    this.options = { ...DEFAULT_OPTIONS, ..._.pickBy(opt) }
+    this.options = { ...DEFAULT_OPTIONS, ...opt }
   }
 
   public addListener(listener: TrainingListener) {


### PR DESCRIPTION
The `max training` cli option didn't allow the value 0. Setting max training to 0 will disable the training on the nlu server. 

Since the value 0 is falsy in typescript it was using the default value for max training. By removing `pickBy` from lodash it is working properly.