### PR TITLE
chore: ensure launch.json uses node 12

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,11 +6,12 @@
   "configurations": [
     {
       "type": "pwa-node",
+      "runtimeVersion": "12.13.0",
       "request": "launch",
       "name": "Debug NLU Server",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/packages/nlu-cli/dist/index.js",
-      "console": "integratedTerminal",
+      "console": "internalConsole",
       "sourceMaps": true,
       "autoAttachChildProcesses": true,
       "args": ["--config=./config.json"],
@@ -18,11 +19,12 @@
     },
     {
       "type": "pwa-node",
+      "runtimeVersion": "12.13.0",
       "request": "launch",
       "name": "Debug Lang Server",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/packages/nlu-cli/dist/index.js",
-      "console": "integratedTerminal",
+      "console": "internalConsole",
       "sourceMaps": true,
       "autoAttachChildProcesses": true,
       "args": ["lang", "--dim=100"],
@@ -30,11 +32,12 @@
     },
     {
       "type": "pwa-node",
+      "runtimeVersion": "12.13.0",
       "request": "launch",
       "name": "Debug Download Model",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/packages/nlu-cli/dist/index.js",
-      "console": "integratedTerminal",
+      "console": "internalConsole",
       "sourceMaps": true,
       "autoAttachChildProcesses": true,
       "args": ["download", "--lang=en", "--dim=100"],
@@ -42,23 +45,24 @@
     },
     {
       "type": "node",
+      "runtimeVersion": "12.13.0",
       "request": "launch",
       "name": "Debug Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["${fileBasenameNoExtension}"],
-      "console": "integratedTerminal",
+      "console": "internalConsole",
       "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true,
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }
     },
     {
       "type": "pwa-node",
+      "runtimeVersion": "12.13.0",
       "request": "launch",
       "name": "Debug App tests",
       "cwd": "${workspaceFolder}/packages/nlu-cli",
-      "console": "integratedTerminal",
+      "console": "internalConsole",
       "args": [
         "${workspaceFolder}/packages/nlu-cli/node_modules/.bin/jest",
         "--rootDir=${workspaceFolder}/packages/nlu-cli",


### PR DESCRIPTION
I lost about an hour because of that lol...

Basically Knex `"^0.20.1"` only works with node 12 and vscode was using node 16 when debugging